### PR TITLE
feat(helper): add async helpers

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,9 @@ jobs:
         with:
           components: clippy
       - name: Run Clippy
-        run: cargo clippy --all-targets --all-features
+        run: |
+          cargo clippy --all-targets --features tokio
+          cargo clippy --all-targets --features async-process
   build:
     name: Rust Build & Test (Stable)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,21 @@
 version = 3
 
 [[package]]
+name = "addr2line"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+dependencies = [
+ "gimli",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -47,7 +62,7 @@ version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -57,14 +72,120 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "async-channel"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89b47800b0be77592da0afd425cc03468052844aff33b84e33cc696f64e77b6a"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
+dependencies = [
+ "async-lock",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "tracing",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63255f1dc2381611000436537bbedfe83183faa303a5a0edaf191edef06526bb"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+ "tracing",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "637e00349800c0bdf8bfc21ebbc0b6524abea702b0da4168ac00d070d0c0b9f3"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
 name = "autocfg"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
+
+[[package]]
+name = "backtrace"
+version = "0.3.74"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
+dependencies = [
+ "addr2line",
+ "cfg-if",
+ "libc",
+ "miniz_oxide",
+ "object",
+ "rustc-demangle",
+ "windows-targets",
+]
 
 [[package]]
 name = "bit-set"
@@ -86,6 +207,25 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "blocking"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703f41c54fc768e63e091340b424302bb1c29ef4aa0c7f10fe849dfb114d29ea"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
+
+[[package]]
+name = "bytes"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
 
 [[package]]
 name = "camino"
@@ -146,6 +286,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22ec99545bb0ed0ea7bb9b8e1e9122ea386ff8a48c0922e43f36d45ab09e0e80"
+
+[[package]]
 name = "datatest-stable"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -158,10 +313,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "errno"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "534c5cf6194dfab3db3242765c03bbe257cf92f22b38f6bc0c58d59108a820ba"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "escape8259"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5692dd7b5a1978a5aeb0ce83b7655c58ca8efdcb79d21036ea249da95afec2c6"
+
+[[package]]
+name = "event-listener"
+version = "5.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6032be9bd27023a771701cc49f9f053c751055f71efb2e0ae5c15809093675ba"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f214dc438f977e6d4e3500aaa277f5ad94ca83fbbd9b1a15713ce2344ccc5a1"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fancy-regex"
@@ -173,6 +359,12 @@ dependencies = [
  "regex-automata",
  "regex-syntax",
 ]
+
+[[package]]
+name = "fastrand"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "futures"
@@ -223,6 +415,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-lite"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -252,10 +457,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "gimli"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
+
+[[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -288,6 +511,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -310,10 +539,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
+name = "mio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80e04d1dcff3aae0704555fe5fee3bcfaf3d1fdf8a7e521d5b9d2b42acb52cec"
+dependencies = [
+ "hermit-abi 0.3.9",
+ "libc",
+ "wasi",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "nftables"
 version = "0.5.0"
 dependencies = [
+ "async-process",
  "datatest-stable",
+ "futures-lite",
  "serde",
  "serde_json",
  "serde_path_to_error",
@@ -321,6 +573,16 @@ dependencies = [
  "strum",
  "strum_macros",
  "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "object"
+version = "0.36.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -328,6 +590,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -363,6 +631,32 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi 0.4.0",
+ "pin-project-lite",
+ "rustix",
+ "tracing",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -407,6 +701,25 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustix"
+version = "0.38.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustversion"
@@ -518,6 +831,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -589,6 +911,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio"
+version = "1.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cec9b21b0450273377fc97bd4c33a8acffc8c996c987a7c5b319a0083707551"
+dependencies = [
+ "backtrace",
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "signal-hook-registry",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -611,12 +964,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
 name = "winapi-util"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,15 @@ exclude = [
 ]
 
 [dependencies]
+async-process = { version = "2.3.0", optional = true }
+futures-lite = { version = "2.5.0", optional = true }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = { version = "1.0.135" }
 serde_path_to_error = "0.1"
 strum = "0.26.3"
 strum_macros = "0.26.4"
 thiserror = "2.0.9"
+tokio = { version = "1.38.1", optional = true, features = ["process", "io-util"] }
 
 [dev-dependencies]
 datatest-stable = "0.3.2"
@@ -32,3 +35,7 @@ serial_test = "3.2.0"
 [[test]]
 name = "deserialize"
 harness = false
+
+[features]
+tokio = ["dep:tokio"]
+async-process = ["dep:async-process", "dep:futures-lite"]

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -18,6 +18,9 @@ pub const DEFAULT_NFT: Option<&str> = None;
 /// Do not use additional arguments to the `nft` executable.
 pub const DEFAULT_ARGS: &[&str] = &[];
 
+#[cfg(all(feature = "tokio", feature = "async-process"))]
+compile_error!("features `tokio` and `async-process` are mutually exclusive");
+
 /// Error during `nft` execution.
 #[derive(Error, Debug)]
 pub enum NftablesError {
@@ -88,7 +91,10 @@ where
     A: AsRef<OsStr> + ?Sized + 'a,
     I: IntoIterator<Item = &'a A> + 'a,
 {
-    let mut nft_cmd = get_command(program);
+    let program = program
+        .map(AsRef::as_ref)
+        .unwrap_or(NFT_EXECUTABLE.as_ref());
+    let mut nft_cmd = Command::new(program);
     let nft_cmd = nft_cmd.arg("-j");
     let mut args = args.into_iter();
     let nft_cmd = match args.next() {
@@ -98,16 +104,81 @@ where
     let process_result = nft_cmd.output();
     let process_result = process_result.map_err(|e| NftablesError::NftExecution {
         inner: e,
-        program: nft_cmd.get_program().to_os_string(),
+        program: program.into(),
     })?;
 
-    let stdout = read_output(nft_cmd, process_result.stdout)?;
+    let stdout = read_output(program, process_result.stdout)?;
 
     if !process_result.status.success() {
-        let stderr = read_output(nft_cmd, process_result.stderr)?;
+        let stderr = read_output(program, process_result.stderr)?;
 
         return Err(NftablesError::NftFailed {
-            program: nft_cmd.get_program().to_os_string(),
+            program: program.into(),
+            hint: "getting the current ruleset".to_string(),
+            stdout,
+            stderr,
+        });
+    }
+    Ok(stdout)
+}
+
+#[cfg(any(feature = "tokio", feature = "async-process"))]
+pub async fn get_current_ruleset_async() -> Result<Nftables<'static>, NftablesError> {
+    get_current_ruleset_with_args_async(DEFAULT_NFT, DEFAULT_ARGS).await
+}
+
+#[cfg(any(feature = "tokio", feature = "async-process"))]
+pub async fn get_current_ruleset_with_args_async<'a, P, A, I>(
+    program: Option<&P>,
+    args: I,
+) -> Result<Nftables<'static>, NftablesError>
+where
+    P: AsRef<OsStr> + ?Sized,
+    A: AsRef<OsStr> + ?Sized + 'a,
+    I: IntoIterator<Item = &'a A> + 'a,
+{
+    let output = get_current_ruleset_raw_async(program, args).await?;
+    serde_json::from_str(&output).map_err(NftablesError::NftInvalidJson)
+}
+
+#[cfg(any(feature = "tokio", feature = "async-process"))]
+pub async fn get_current_ruleset_raw_async<'a, P, A, I>(
+    program: Option<&P>,
+    args: I,
+) -> Result<String, NftablesError>
+where
+    P: AsRef<OsStr> + ?Sized,
+    A: AsRef<OsStr> + ?Sized + 'a,
+    I: IntoIterator<Item = &'a A> + 'a,
+{
+    #[cfg(feature = "async-process")]
+    use async_process::Command;
+    #[cfg(feature = "tokio")]
+    use tokio::process::Command;
+
+    let program = program
+        .map(AsRef::as_ref)
+        .unwrap_or(NFT_EXECUTABLE.as_ref());
+    let mut nft_cmd = Command::new(program);
+    let nft_cmd = nft_cmd.arg("-j");
+    let mut args = args.into_iter();
+    let nft_cmd = match args.next() {
+        Some(arg) => nft_cmd.arg(arg).args(args),
+        None => nft_cmd.args(["list", "ruleset"]),
+    };
+    let process_result = nft_cmd.output().await;
+    let process_result = process_result.map_err(|e| NftablesError::NftExecution {
+        inner: e,
+        program: program.into(),
+    })?;
+
+    let stdout = read_output(program, process_result.stdout)?;
+
+    if !process_result.status.success() {
+        let stderr = read_output(program, process_result.stderr)?;
+
+        return Err(NftablesError::NftFailed {
+            program: program.into(),
             hint: "getting the current ruleset".to_string(),
             stdout,
             stderr,
@@ -163,7 +234,10 @@ where
     A: AsRef<OsStr> + ?Sized + 'a,
     I: IntoIterator<Item = &'a A> + 'a,
 {
-    let mut nft_cmd = get_command(program);
+    let program = program
+        .map(AsRef::as_ref)
+        .unwrap_or(NFT_EXECUTABLE.as_ref());
+    let mut nft_cmd = Command::new(program);
     let default_args = ["-j", "-f", "-"];
     let process = nft_cmd
         .args(args)
@@ -172,7 +246,7 @@ where
         .stdout(Stdio::piped())
         .spawn();
     let mut process = process.map_err(|e| NftablesError::NftExecution {
-        program: nft_cmd.get_program().to_os_string(),
+        program: program.into(),
         inner: e,
     })?;
 
@@ -180,7 +254,7 @@ where
     stdin
         .write_all(payload.as_bytes())
         .map_err(|e| NftablesError::NftExecution {
-            program: nft_cmd.get_program().to_os_string(),
+            program: program.into(),
             inner: e,
         })?;
     drop(stdin);
@@ -189,33 +263,116 @@ where
     match result {
         Ok(output) if output.status.success() => Ok(()),
         Ok(process_result) => {
-            let stdout = read_output(&nft_cmd, process_result.stdout)?;
-            let stderr = read_output(&nft_cmd, process_result.stderr)?;
+            let stdout = read_output(program, process_result.stdout)?;
+            let stderr = read_output(program, process_result.stderr)?;
 
             Err(NftablesError::NftFailed {
-                program: nft_cmd.get_program().to_os_string(),
+                program: program.into(),
                 hint: "applying ruleset".to_string(),
                 stdout,
                 stderr,
             })
         }
         Err(e) => Err(NftablesError::NftExecution {
-            program: nft_cmd.get_program().to_os_string(),
+            program: program.into(),
             inner: e,
         }),
     }
 }
 
-fn get_command<S: AsRef<OsStr>>(program: Option<S>) -> Command {
-    match program {
-        Some(program) => Command::new(program),
-        None => Command::new(NFT_EXECUTABLE),
+#[cfg(any(feature = "tokio", feature = "async-process"))]
+pub async fn apply_ruleset_async(nftables: &Nftables<'_>) -> Result<(), NftablesError> {
+    apply_ruleset_with_args_async(nftables, DEFAULT_NFT, DEFAULT_ARGS).await
+}
+
+#[cfg(any(feature = "tokio", feature = "async-process"))]
+pub async fn apply_ruleset_with_args_async<'a, P, A, I>(
+    nftables: &Nftables<'_>,
+    program: Option<&P>,
+    args: I,
+) -> Result<(), NftablesError>
+where
+    P: AsRef<OsStr> + ?Sized,
+    A: AsRef<OsStr> + ?Sized + 'a,
+    I: IntoIterator<Item = &'a A> + 'a,
+{
+    let nftables = serde_json::to_string(nftables).expect("failed to serialize Nftables struct");
+    apply_ruleset_raw_async(&nftables, program, args).await
+}
+
+#[cfg(any(feature = "tokio", feature = "async-process"))]
+pub async fn apply_ruleset_raw_async<'a, P, A, I>(
+    payload: &str,
+    program: Option<&P>,
+    args: I,
+) -> Result<(), NftablesError>
+where
+    P: AsRef<OsStr> + ?Sized,
+    A: AsRef<OsStr> + ?Sized + 'a,
+    I: IntoIterator<Item = &'a A> + 'a,
+{
+    #[cfg(feature = "async-process")]
+    use async_process::Command;
+    #[cfg(feature = "async-process")]
+    use futures_lite::io::AsyncWriteExt;
+    #[cfg(feature = "tokio")]
+    use tokio::io::AsyncWriteExt;
+    #[cfg(feature = "tokio")]
+    use tokio::process::Command;
+
+    let program = program
+        .map(AsRef::as_ref)
+        .unwrap_or(NFT_EXECUTABLE.as_ref());
+    let mut nft_cmd = Command::new(program);
+    let default_args = ["-j", "-f", "-"];
+    let process = nft_cmd
+        .args(args)
+        .args(default_args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .spawn();
+    let mut process = process.map_err(|e| NftablesError::NftExecution {
+        program: program.into(),
+        inner: e,
+    })?;
+
+    let mut stdin = process.stdin.take().unwrap();
+    stdin
+        .write_all(payload.as_bytes())
+        .await
+        .map_err(|e| NftablesError::NftExecution {
+            program: program.into(),
+            inner: e,
+        })?;
+    drop(stdin);
+
+    #[cfg(feature = "tokio")]
+    let result = process.wait_with_output().await;
+    #[cfg(feature = "async-process")]
+    let result = process.output().await;
+    match result {
+        Ok(output) if output.status.success() => Ok(()),
+        Ok(process_result) => {
+            let stdout = read_output(program, process_result.stdout)?;
+            let stderr = read_output(program, process_result.stderr)?;
+
+            Err(NftablesError::NftFailed {
+                program: program.into(),
+                hint: "applying ruleset".to_string(),
+                stdout,
+                stderr,
+            })
+        }
+        Err(e) => Err(NftablesError::NftExecution {
+            program: program.into(),
+            inner: e,
+        }),
     }
 }
 
-fn read_output(cmd: &Command, bytes: Vec<u8>) -> Result<String, NftablesError> {
+fn read_output(program: impl Into<OsString>, bytes: Vec<u8>) -> Result<String, NftablesError> {
     String::from_utf8(bytes).map_err(|e| NftablesError::NftOutputEncoding {
         inner: e,
-        program: cmd.get_program().to_os_string(),
+        program: program.into(),
     })
 }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -122,11 +122,17 @@ where
     Ok(stdout)
 }
 
+/// Get the rule set that is currently active in the kernel asynchronously.
+///
+/// See the synchronous [`get_current_ruleset`] for more information.
 #[cfg(any(feature = "tokio", feature = "async-process"))]
 pub async fn get_current_ruleset_async() -> Result<Nftables<'static>, NftablesError> {
     get_current_ruleset_with_args_async(DEFAULT_NFT, DEFAULT_ARGS).await
 }
 
+/// Get the current rule set asynchronously by calling a custom `nft` with custom arguments.
+///
+/// See the synchronous [`get_current_ruleset_with_args`] for more information.
 #[cfg(any(feature = "tokio", feature = "async-process"))]
 pub async fn get_current_ruleset_with_args_async<'a, P, A, I>(
     program: Option<&P>,
@@ -141,6 +147,9 @@ where
     serde_json::from_str(&output).map_err(NftablesError::NftInvalidJson)
 }
 
+/// Get the current raw rule set json asynchronously by calling a custom `nft` with custom arguments.
+///
+/// See the synchronous [`get_current_ruleset_raw`] for more information.
 #[cfg(any(feature = "tokio", feature = "async-process"))]
 pub async fn get_current_ruleset_raw_async<'a, P, A, I>(
     program: Option<&P>,
@@ -280,11 +289,17 @@ where
     }
 }
 
+/// Apply the given rule set to the kernel asynchronously.
+///
+/// See the synchronous [`apply_ruleset`] for more information.
 #[cfg(any(feature = "tokio", feature = "async-process"))]
 pub async fn apply_ruleset_async(nftables: &Nftables<'_>) -> Result<(), NftablesError> {
     apply_ruleset_with_args_async(nftables, DEFAULT_NFT, DEFAULT_ARGS).await
 }
 
+/// Apply the given rule set asynchronously by calling a custom `nft` with custom arguments.
+///
+/// See the synchronous [`apply_ruleset_with_args`] for more information.
 #[cfg(any(feature = "tokio", feature = "async-process"))]
 pub async fn apply_ruleset_with_args_async<'a, P, A, I>(
     nftables: &Nftables<'_>,
@@ -300,6 +315,9 @@ where
     apply_ruleset_raw_async(&nftables, program, args).await
 }
 
+/// Apply the given raw rule set json asynchronously by calling a custom `nft` with custom arguments.
+///
+/// See the synchronous [`apply_ruleset_raw`] for more information.
 #[cfg(any(feature = "tokio", feature = "async-process"))]
 pub async fn apply_ruleset_raw_async<'a, P, A, I>(
     payload: &str,


### PR DESCRIPTION
Basically integrates functions from the nftables_async crate here, with both tokio and async-process support behind feature gates.

Also corrected some of the behaviour differences in nftables_async, e.g. get_current_ruleset_raw passes additional arguments (keeping "-j list ruleset" intact) in nftables_async, but replaces the default arguments (except -j) here.