### PR TITLE
helper: Change API to AsRef<OsStr> based API

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ use nftables::{batch::Batch, helper, schema, types};
 /// Applies a ruleset to nftables.
 fn test_apply_ruleset() {
     let ruleset = example_ruleset();
-    helper::apply_ruleset(&ruleset, None, None).unwrap();
+    helper::apply_ruleset(&ruleset).unwrap();
 }
 
 fn example_ruleset() -> schema::Nftables<'static> {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -9,6 +9,7 @@ use thiserror::Error;
 
 use crate::schema::Nftables;
 
+/// Default `nft` executable.
 const NFT_EXECUTABLE: &str = "nft"; // search in PATH
 
 /// Use the default `nft` executable.
@@ -17,6 +18,7 @@ pub const DEFAULT_NFT: Option<&str> = None;
 /// Do not use additional arguments to the `nft` executable.
 pub const DEFAULT_ARGS: Option<&[&str]> = None;
 
+/// Error during `nft` execution.
 #[derive(Error, Debug)]
 pub enum NftablesError {
     #[error("unable to execute {program:?}: {inner}")]
@@ -37,10 +39,23 @@ pub enum NftablesError {
     },
 }
 
+/// Get the rule set that is currently active in the kernel.
+///
+/// This is done by calling the default `nft` executable with default arguments.
 pub fn get_current_ruleset() -> Result<Nftables<'static>, NftablesError> {
     get_current_ruleset_with_args(DEFAULT_NFT, DEFAULT_ARGS)
 }
 
+/// Get the current rule set by calling a custom `nft` with custom arguments.
+///
+/// If `program` is [Some], then this program will be called instead of the
+/// default `nft` executable.
+/// [DEFAULT_NFT] can be passed to call the default `nft`.
+///
+/// If `args` is [Some], then these `nft` arguments will be used instead of the
+/// default arguments `list` and `ruleset`.
+/// [DEFAULT_ARGS] can be passed to use the default arguments.
+/// Note that the argument `-j` is always added in front of `args`.
 pub fn get_current_ruleset_with_args<P: AsRef<OsStr>, A: AsRef<OsStr>>(
     program: Option<P>,
     args: Option<&[A]>,
@@ -49,6 +64,16 @@ pub fn get_current_ruleset_with_args<P: AsRef<OsStr>, A: AsRef<OsStr>>(
     serde_json::from_str(&output).map_err(NftablesError::NftInvalidJson)
 }
 
+/// Get the current raw rule set json by calling a custom `nft` with custom arguments.
+///
+/// If `program` is [Some], then this program will be called instead of the
+/// default `nft` executable.
+/// [DEFAULT_NFT] can be passed to call the default `nft`.
+///
+/// If `args` is [Some], then these `nft` arguments will be used instead of the
+/// default arguments `list` and `ruleset`.
+/// [DEFAULT_ARGS] can be passed to use the default arguments.
+/// Note that the argument `-j` is always added in front of `args`.
 pub fn get_current_ruleset_raw<P: AsRef<OsStr>, A: AsRef<OsStr>>(
     program: Option<P>,
     args: Option<&[A]>,
@@ -80,10 +105,21 @@ pub fn get_current_ruleset_raw<P: AsRef<OsStr>, A: AsRef<OsStr>>(
     Ok(stdout)
 }
 
+/// Apply the given rule set to the kernel.
+///
+/// This is done by calling the default `nft` executable with default arguments.
 pub fn apply_ruleset(nftables: &Nftables) -> Result<(), NftablesError> {
     apply_ruleset_with_args(nftables, DEFAULT_NFT, DEFAULT_ARGS)
 }
 
+/// Apply the given rule set by calling a custom `nft` with custom arguments.
+///
+/// If `program` is [Some], then this program will be called instead of the
+/// default `nft` executable.
+/// [DEFAULT_NFT] can be passed to call the default `nft`.
+///
+/// If `args` is [Some], then these `nft` arguments will be added in front of the
+/// other arguments `-j` and `-f -` that are always required internally.
 pub fn apply_ruleset_with_args<P: AsRef<OsStr>, A: AsRef<OsStr>>(
     nftables: &Nftables,
     program: Option<P>,
@@ -93,6 +129,14 @@ pub fn apply_ruleset_with_args<P: AsRef<OsStr>, A: AsRef<OsStr>>(
     apply_ruleset_raw(&nftables, program, args)
 }
 
+/// Apply the given raw rule set json by calling a custom `nft` with custom arguments.
+///
+/// If `program` is [Some], then this program will be called instead of the
+/// default `nft` executable.
+/// [DEFAULT_NFT] can be passed to call the default `nft`.
+///
+/// If `args` is [Some], then these `nft` arguments will be added in front of the
+/// other arguments `-j` and `-f -` that are always required internally.
 pub fn apply_ruleset_raw<P: AsRef<OsStr>, A: AsRef<OsStr>>(
     payload: &str,
     program: Option<P>,

--- a/tests/helper_tests.rs
+++ b/tests/helper_tests.rs
@@ -15,14 +15,14 @@ use serial_test::serial;
 /// Reads current ruleset from nftables and reads it to `Nftables` Rust struct.
 fn test_list_ruleset() {
     flush_ruleset().expect("failed to flush ruleset");
-    helper::get_current_ruleset(None, None).unwrap();
+    helper::get_current_ruleset().unwrap();
 }
 
 #[test]
 #[ignore]
 /// Attempts to read current ruleset from nftables using non-existing nft binary.
 fn test_list_ruleset_invalid_program() {
-    let result = helper::get_current_ruleset(Some("/dev/null/nft"), None);
+    let result = helper::get_current_ruleset_with_args(Some("/dev/null/nft"), helper::DEFAULT_ARGS);
     let err =
         result.expect_err("getting the current ruleset should fail with non-existing nft binary");
     assert!(matches!(err, NftablesError::NftExecution { .. }));
@@ -35,16 +35,16 @@ fn test_list_ruleset_invalid_program() {
 fn test_nft_args_list_map_set() {
     flush_ruleset().expect("failed to flush ruleset");
     let ruleset = example_ruleset(false);
-    nftables::helper::apply_ruleset(&ruleset, None, None).unwrap();
+    nftables::helper::apply_ruleset(&ruleset).unwrap();
     // nft should return two list object: metainfo and the set/map
-    let applied = helper::get_current_ruleset(
-        None,
+    let applied = helper::get_current_ruleset_with_args(
+        helper::DEFAULT_NFT,
         Some(&["list", "map", "ip", "test-table-01", "test_map"]),
     )
     .unwrap();
     assert_eq!(2, applied.objects.len());
-    let applied = helper::get_current_ruleset(
-        None,
+    let applied = helper::get_current_ruleset_with_args(
+        helper::DEFAULT_NFT,
         Some(&["list", "set", "ip", "test-table-01", "test_set"]),
     )
     .unwrap();
@@ -58,7 +58,7 @@ fn test_nft_args_list_map_set() {
 fn test_apply_ruleset() {
     flush_ruleset().expect("failed to flush ruleset");
     let ruleset = example_ruleset(true);
-    nftables::helper::apply_ruleset(&ruleset, None, None).unwrap();
+    nftables::helper::apply_ruleset(&ruleset).unwrap();
 }
 
 #[test]
@@ -75,7 +75,7 @@ fn test_remove_unknown_table() {
     }));
     let ruleset = batch.to_nftables();
 
-    let result = nftables::helper::apply_ruleset(&ruleset, None, None);
+    let result = nftables::helper::apply_ruleset(&ruleset);
     let err = result.expect_err("Expecting nftables error for unknown table.");
     assert!(matches!(err, NftablesError::NftFailed { .. }));
 }
@@ -149,5 +149,5 @@ fn get_flush_ruleset() -> schema::Nftables<'static> {
 
 fn flush_ruleset() -> Result<(), NftablesError> {
     let ruleset = get_flush_ruleset();
-    nftables::helper::apply_ruleset(&ruleset, None, None)
+    nftables::helper::apply_ruleset(&ruleset)
 }

--- a/tests/helper_tests.rs
+++ b/tests/helper_tests.rs
@@ -39,13 +39,13 @@ fn test_nft_args_list_map_set() {
     // nft should return two list object: metainfo and the set/map
     let applied = helper::get_current_ruleset_with_args(
         helper::DEFAULT_NFT,
-        Some(&["list", "map", "ip", "test-table-01", "test_map"]),
+        ["list", "map", "ip", "test-table-01", "test_map"],
     )
     .unwrap();
     assert_eq!(2, applied.objects.len());
     let applied = helper::get_current_ruleset_with_args(
         helper::DEFAULT_NFT,
-        Some(&["list", "set", "ip", "test-table-01", "test_set"]),
+        ["list", "set", "ip", "test-table-01", "test_set"],
     )
     .unwrap();
     assert_eq!(2, applied.objects.len());


### PR DESCRIPTION
This improves the versatility of the API.
With the new API there are more ideomatic options for the user like
&Path, PathBuf and also still &str and more.
    
This is an API incompatible change.
I think it's not really possible to make this API compatible,
because the None-values need explicit type annotations due to the trait based API.
The default None-based API has been replaced by functions without arguments
to make the common case easier to use.
    
The user code changes are probably minimal in most cases, because None arguments
can just be removed and string arguments keep working as-is due to the std
implementations of AsRef.
Convenience constants are provided to make use of the None-arguments
to the _with_args() functions more readable and easier to use.
    
As a side effect this change also removes an unnecessary allocation of the program
name string in case of a successful execution.

Closes: #107

Any comments, suggestions, improvements? Please let me know.

Thanks!