### PR TITLE
Fix NAT port ranges

### DIFF
--- a/resources/test/json/nat.json
+++ b/resources/test/json/nat.json
@@ -50,6 +50,54 @@
               "op": "==",
               "left": {
                 "meta": {
+                  "key": "l4proto"
+                }
+              },
+              "right": "tcp"
+            }
+          },
+          {
+            "match": {
+              "op": "!=",
+              "left": {
+                "payload": {
+                  "protocol": "ip",
+                  "field": "daddr"
+                }
+              },
+              "right": {
+                "prefix": {
+                  "addr": "192.168.122.0",
+                  "len": 24
+                }
+              }
+            }
+          },
+          {
+            "masquerade": {
+              "port": {
+                "range": [
+                  1024,
+                  65535
+                ]
+              }
+            }
+          }
+        ]
+      }
+    },
+    {
+      "rule": {
+        "family": "ip",
+        "table": "nat",
+        "chain": "postrouting",
+        "handle": 4,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "meta": {
                   "key": "oifname"
                 }
               },

--- a/resources/test/nft/nat.nft
+++ b/resources/test/nft/nat.nft
@@ -7,9 +7,9 @@ table ip nat {
 		type nat hook prerouting priority 0; policy accept;
 	}
 
-	# for all packets to WAN, after routing, replace source address with primary IP of WAN interface
 	chain postrouting {
 		type nat hook postrouting priority 100; policy accept;
+		meta l4proto tcp ip daddr != 192.168.122.0/24 masquerade to :1024-65535
 		oifname "wan0" masquerade
 	}
 }

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -257,7 +257,7 @@ pub struct NAT<'a> {
     pub family: Option<NATFamily>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Port to translate to.
-    pub port: Option<u32>,
+    pub port: Option<Expression<'a>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Flag(s).
     pub flags: Option<HashSet<NATFlag>>,


### PR DESCRIPTION
Fixes #111 by allowing `Expression` as NAT `port`.