### PR TITLE
Add support for exporting JSON schema to file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -314,6 +314,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "feeef44e73baff3a26d371801df019877a9866a8c493d315ab00177843314f35"
+
+[[package]]
 name = "errno"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -458,6 +464,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi 0.13.3+wasi-0.2.2",
+ "windows-targets",
+]
+
+[[package]]
 name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,7 +567,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -560,12 +578,14 @@ dependencies = [
  "async-process",
  "datatest-stable",
  "futures-lite",
+ "schemars",
  "serde",
  "serde_json",
  "serde_path_to_error",
  "serial_test",
  "strum",
  "strum_macros",
+ "tempfile",
  "thiserror",
  "tokio",
 ]
@@ -746,6 +766,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -771,6 +815,17 @@ name = "serde_derive"
 version = "1.0.217"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -885,6 +940,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c246215d7d24f48ae091a2902398798e05d978b24315d6efbc00ede9a8bb91"
+dependencies = [
+ "cfg-if",
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,6 +1031,15 @@ name = "wasi"
 version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+
+[[package]]
+name = "wasi"
+version = "0.13.3+wasi-0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+dependencies = [
+ "wit-bindgen-rt",
+]
 
 [[package]]
 name = "winapi-util"
@@ -1053,3 +1131,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+dependencies = [
+ "bitflags",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ exclude = [
 [dependencies]
 async-process = { version = "2.3.0", optional = true }
 futures-lite = { version = "2.6.0", optional = true }
+schemars = "0.8.21"
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = { version = "1.0.138" }
 serde_path_to_error = "0.1"
@@ -31,6 +32,7 @@ tokio = { version = "1.43.0", optional = true, features = ["process", "io-util"]
 [dev-dependencies]
 datatest-stable = "0.3.2"
 serial_test = "3.2.0"
+tempfile = "3.16.0"
 
 [[test]]
 name = "deserialize"

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@
 
 - 📄 **JSON Parsing and Generation**: Offers detailed parsing and generation capabilities for nftables rulesets in JSON format, enabling seamless integration and manipulation of rulesets.
 
+- 💾 **JSON Schema generation for nftables**: Allows to create and export a JSON Schema for further usage derived from the explicit Rust types.
+
 - 💡 **Inspired by nftnl-rs**: While taking inspiration from [nftnl-rs](https://github.com/mullvad/nftnl-rs), `nftables-rs` focuses on utilizing the JSON API for broader accessibility and catering to diverse use cases.
 
 ## Motivation
@@ -117,6 +119,14 @@ fn test_chain_table_rule_inet() {
     let parsed: Nftables = serde_json::from_value(json).unwrap();
     assert_eq!(expected, parsed);
 }
+```
+
+### Export JSON Schema
+
+Export a JSON Schema to a file (if no path is set it defaults to `./nftables.schema.json`).
+
+```bash
+./nftables-rs schema <export-path | './nftables.schema.json'>
 ```
 
 ## MSRV (Minimum Supported Rust Version)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,121 @@
+use crate::schema::Nftables;
+use schemars::schema_for;
+use std::{env::args, fs, io::Read, process::exit};
+
+/// Get command arguments.
+///
+/// This skips the first argument, because it is the program path itself.
+pub fn collect_command_args() -> Vec<String> {
+    args().skip(1).collect()
+}
+
+/// Dispatch command line arguments to commands.
+pub fn handle_args(args: Vec<String>) {
+    let mut args = args.into_iter();
+
+    if let Some(command) = &args.next() {
+        if command == "schema" {
+            generate_json_schema(args.next().unwrap_or("./nftables.schema.json".to_string()));
+            return;
+        }
+        eprintln!("Unknown command: `{command}`. Try again with the schema command to generate a JSON Schema or call with stdin only.");
+        exit(1);
+    }
+    deserialize_stdin();
+}
+
+fn generate_json_schema(schema_dst_path: String) {
+    let schema = schema_for!(Nftables);
+
+    if let Err(err) = fs::write(
+        schema_dst_path.clone(),
+        serde_json::to_string_pretty(&schema).expect("Serde should serialize the document"),
+    ) {
+        eprintln!("Failed to write data to file: {err}");
+        exit(1);
+    }
+
+    println!("Wrote schema data to: {schema_dst_path}");
+}
+
+/// Deserializes nftables JSON from the standard input and prints the result.
+///
+/// This is the default behavior when the executable is called without any
+/// arguments.
+fn deserialize_stdin() {
+    use std::io;
+    let mut buffer = String::new();
+
+    match io::stdin().read_to_string(&mut buffer) {
+        Err(error) => panic!("Problem opening the file: {:?}", error),
+        Ok(_) => {
+            println!("Document: {}", &buffer);
+
+            let deserializer = &mut serde_json::Deserializer::from_str(&buffer);
+            let result: Result<Nftables, _> = serde_path_to_error::deserialize(deserializer);
+
+            match result {
+                Ok(_) => println!("Result: {:?}", result),
+                Err(err) => {
+                    panic!("Deserialization error: {}", err);
+                }
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serial_test::serial;
+    use std::{env, fs};
+    use tempfile::TempDir;
+
+    #[test]
+    // Use serial due to altering the value
+    // of CWD
+    #[serial]
+    fn test_handle_args_schema_default_path() {
+        let tmp_dir = TempDir::new().expect("Should create a temp dir inside `env::tmp_dir`");
+        let path = tmp_dir.path().join("nftables.schema.json");
+
+        // Little hack, to have "control" over the directory
+        // in which the default file is created
+        let cwd = env::current_dir().expect("Should get current dir");
+        let _ = env::set_current_dir(tmp_dir.path());
+        handle_args(vec!["schema".to_string()]);
+        let _ = env::set_current_dir(cwd);
+
+        assert!(fs::metadata(&path).is_ok());
+    }
+
+    #[test]
+    fn test_handle_args_schema_custom_path() {
+        let tmp_dir = TempDir::new().expect("Should create a temp dir inside `env::tmp_dir`");
+        let path = tmp_dir.path().join("test_nftables.schema.json");
+        handle_args(vec![
+            "schema".to_string(),
+            path.to_str().unwrap().to_string(),
+        ]);
+
+        assert!(fs::metadata(&path).is_ok());
+    }
+
+    #[test]
+    fn test_generate_json_schema() {
+        let tmp_dir = TempDir::new().expect("Should create a temp dir inside `env::tmp_dir`");
+        let path = tmp_dir.path().join("nftables.schema.json");
+
+        generate_json_schema(path.to_str().unwrap().to_string());
+
+        assert!(fs::metadata(&path).is_ok());
+
+        let content = fs::read_to_string(&path).unwrap();
+        // Check if generated file contains JSON schema "$schema" field
+        assert!(content.contains("$schema"));
+        assert_eq!(
+            content.to_string(),
+            serde_json::to_string_pretty(&schema_for!(Nftables)).expect("")
+        )
+    }
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,9 +1,10 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::HashSet};
 
 use crate::stmt::{Counter, JumpTarget, Statement};
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 /// Expressions are the building blocks of (most) [statements](crate::stmt::Statement).
 /// In their most basic form, they are just immediate values represented as a
@@ -35,7 +36,7 @@ pub enum Expression<'a> {
     Verdict(Verdict<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Wrapper for non-immediate [Expressions](Expression).
 pub enum NamedExpression<'a> {
@@ -88,7 +89,7 @@ pub enum NamedExpression<'a> {
     Osf(Osf<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "map")]
 /// Map a key to a value.
 pub struct Map<'a> {
@@ -108,7 +109,7 @@ impl Default for Map<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 /// Item in an anonymous set.
 pub enum SetItem<'a> {
@@ -120,7 +121,7 @@ pub enum SetItem<'a> {
     MappingStatement(Expression<'a>, Statement<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "prefix")]
 /// Construct an IPv4 or IPv6 prefix consisting of address part in
 /// [addr](Prefix::addr) and prefix length in [len](Prefix::len).
@@ -131,7 +132,7 @@ pub struct Prefix<'a> {
     pub len: u32,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "range")]
 /// Construct a range of values.
 /// The first array item denotes the lower boundary, the second one the upper
@@ -144,7 +145,7 @@ pub struct Range<'a> {
     pub range: [Expression<'a>; 2],
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 /// Construct a payload expression, i.e. a reference to a certain part of packet
 /// data.
@@ -156,7 +157,7 @@ pub enum Payload<'a> {
     PayloadRaw(PayloadRaw),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Creates a raw payload expression to point at a random number
 /// ([len](PayloadRaw::len)) of bytes at a certain offset
 /// ([offset](PayloadRaw::offset)) from a given reference point
@@ -181,7 +182,7 @@ impl Default for PayloadRaw {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Construct a payload expression, i.e. a reference to a certain part of packet
 /// data.
 ///
@@ -204,7 +205,7 @@ impl Default for PayloadField<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents a protocol layer for [payload](Payload) references.
 pub enum PayloadBase {
@@ -222,7 +223,7 @@ pub enum PayloadBase {
     IH,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "exthdr")]
 /// Create a reference to a field ([field](Exthdr::field)) in an IPv6 extension
 /// header ([name](Exthdr::name)).
@@ -253,7 +254,7 @@ impl Default for Exthdr<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "tcp option")]
 /// Create a reference to a field ([field](TcpOption::field)) of a TCP option
 /// header ([name](TcpOption::field)).
@@ -279,7 +280,7 @@ impl Default for TcpOption<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "sctp chunk")]
 /// Create a reference to a field ([field](SctpChunk::field)) of an SCTP chunk
 /// ((name)[SctpChunk::name]).
@@ -295,7 +296,7 @@ pub struct SctpChunk<'a> {
     pub field: Cow<'a, str>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "meta")]
 /// Create a reference to packet meta data.
 ///
@@ -315,7 +316,7 @@ impl Default for Meta {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents a `meta` key for packet meta data.
 ///
@@ -395,7 +396,7 @@ pub enum MetaKey {
     Nftrace,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "rt")]
 /// Create a reference to packet routing data.
 pub struct RT {
@@ -418,7 +419,7 @@ impl Default for RT {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents a key to reference to packet routing data.
 pub enum RTKey {
@@ -430,7 +431,7 @@ pub enum RTKey {
     MTU,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents a protocol family for use by the [rt](RT) expression.
 pub enum RTFamily {
@@ -440,7 +441,7 @@ pub enum RTFamily {
     IP6,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "ct")]
 /// Create a reference to packet conntrack data.
 pub struct CT<'a> {
@@ -470,7 +471,7 @@ impl Default for CT<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents a protocol family for use by the [ct](CT) expression.
 pub enum CTFamily {
@@ -480,7 +481,7 @@ pub enum CTFamily {
     IP6,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents a direction for use by the [ct](CT) expression.
 pub enum CTDir {
@@ -490,7 +491,7 @@ pub enum CTDir {
     Reply,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "numgen")]
 /// Create a number generator.
 pub struct Numgen {
@@ -516,7 +517,7 @@ impl Default for Numgen {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents a number generator mode.
 pub enum NgMode {
@@ -526,7 +527,7 @@ pub enum NgMode {
     Random,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "jhash")]
 /// Hash packet data (Jenkins Hash).
 pub struct JHash<'a> {
@@ -561,7 +562,7 @@ impl Default for JHash<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "symhash")]
 /// Hash packet data (Symmetric Hash).
 pub struct SymHash {
@@ -582,7 +583,7 @@ impl Default for SymHash {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "fib")]
 /// Perform kernel Forwarding Information Base lookups.
 pub struct Fib {
@@ -605,7 +606,7 @@ impl Default for Fib {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents which data is queried by [fib](Fib) lookup.
 pub enum FibResult {
@@ -617,7 +618,7 @@ pub enum FibResult {
     Type,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents flags for `fib` lookup.
 pub enum FibFlag {
@@ -633,7 +634,7 @@ pub enum FibFlag {
     Oif,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Represents a binary operation to be used in an `Expression`.
 pub enum BinaryOperation<'a> {
     #[serde(rename = "&")]
@@ -657,7 +658,7 @@ pub enum BinaryOperation<'a> {
     RSHIFT(Expression<'a>, Expression<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// A verdict expression (used in [verdict maps](crate::stmt::VerdictMap)).
 ///
@@ -702,7 +703,7 @@ pub enum Verdict<'a> {
     Goto(JumpTarget<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "elem")]
 /// Explicitly set element object.
 ///
@@ -737,7 +738,7 @@ impl Default for Elem<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "socket")]
 /// Construct a reference to packet’s socket.
 pub struct Socket<'a> {
@@ -754,7 +755,7 @@ impl Default for Socket<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// A [socket][Socket] attribute to match on.
 pub enum SocketAttr {
@@ -768,7 +769,7 @@ pub enum SocketAttr {
     Cgroupv2,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "osf")]
 /// Perform OS fingerprinting.
 ///
@@ -784,7 +785,7 @@ pub struct Osf<'a> {
     pub ttl: OsfTtl,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// TTL check mode for [osf](Osf).
 pub enum OsfTtl {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,9 @@ pub mod helper;
 /// Contains node visitors for serde.
 pub mod visitor;
 
+/// Contains handling and parsing of command line arguments.
+pub mod cli;
+
 // Default values for Default implementations.
 const DEFAULT_FAMILY: types::NfFamily = types::NfFamily::INet;
 const DEFAULT_TABLE: &str = "filter";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,28 +1,6 @@
-use std::io::Read;
-
-use nftables::schema::Nftables;
+use nftables::cli;
 
 fn main() {
-    deserialize_stdin();
-}
-
-fn deserialize_stdin() {
-    use std::io;
-    let mut buffer = String::new();
-    match io::stdin().read_to_string(&mut buffer) {
-        Err(error) => panic!("Problem opening the file: {:?}", error),
-        Ok(_) => {
-            println!("Document: {}", &buffer);
-
-            let deserializer = &mut serde_json::Deserializer::from_str(&buffer);
-            let result: Result<Nftables, _> = serde_path_to_error::deserialize(deserializer);
-
-            match result {
-                Ok(_) => println!("Result: {:?}", result),
-                Err(err) => {
-                    panic!("Deserialization error: {}", err);
-                }
-            }
-        }
-    };
+    let args = cli::collect_command_args();
+    cli::handle_args(args);
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,3 +1,4 @@
+use schemars::JsonSchema;
 use std::{borrow::Cow, collections::HashSet};
 
 use crate::{
@@ -9,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use strum_macros::EnumString;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// In general, any JSON input or output is enclosed in an object with a single property named **nftables**.
 ///
 /// See [libnftables-json global structure](Global Structure).
@@ -21,7 +22,7 @@ pub struct Nftables<'a> {
     pub objects: Cow<'a, [NfObject<'a>]>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 /// A [ruleset element](NfListObject) or [command](NfCmd) in an [nftables document](Nftables).
 pub enum NfObject<'a> {
@@ -31,7 +32,7 @@ pub enum NfObject<'a> {
     ListObject(NfListObject<'a>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// A ruleset element in an [nftables document](Nftables).
 pub enum NfListObject<'a> {
@@ -70,7 +71,7 @@ pub enum NfListObject<'a> {
     SynProxy(SynProxy<'a>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// A command is an object with a single property whose name identifies the command.
 ///
@@ -117,7 +118,7 @@ pub enum NfCmd<'a> {
     Rename(Chain<'a>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Reset state in suitable objects, i.e. zero their internal counter.
 pub enum ResetObject<'a> {
@@ -131,7 +132,7 @@ pub enum ResetObject<'a> {
     Quotas(Cow<'a, [Quota<'a>]>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Empty contents in given object, e.g. remove all chains from given table or remove all elements from given set.
 pub enum FlushObject<'a> {
@@ -151,7 +152,7 @@ pub enum FlushObject<'a> {
 
 // Ruleset Elements
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This object describes a table.
 pub struct Table<'a> {
     /// The table’s [family](NfFamily), e.g. "ip" or "ip6".
@@ -177,7 +178,7 @@ impl Default for Table<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This object describes a chain.
 pub struct Chain<'a> {
     /// The table’s family.
@@ -243,7 +244,7 @@ impl Default for Chain<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This object describes a rule.
 ///
 /// Basic building blocks of rules are statements.
@@ -290,7 +291,7 @@ impl Default for Rule<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Named set that holds expression elements.
 pub struct Set<'a> {
     /// The table’s family.
@@ -355,7 +356,7 @@ impl Default for Set<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Named map that holds expression elements.
 /// Maps are a special form of sets in that they translate a unique key to a value.
 pub struct Map<'a> {
@@ -425,7 +426,7 @@ impl Default for Map<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 /// Wrapper for single or concatenated set types.
 /// The set type might be a string, such as `"ipv4_addr"` or an array consisting of strings (for concatenated types).
@@ -436,7 +437,9 @@ pub enum SetTypeValue<'a> {
     Concatenated(Cow<'a, [SetType]>),
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, EnumString)]
+#[derive(
+    Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, EnumString, JsonSchema,
+)]
 #[serde(rename_all = "lowercase")]
 /// Describes a set’s datatype.
 pub enum SetType {
@@ -470,7 +473,7 @@ pub enum SetType {
     Ifname,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Describes a set’s policy.
 pub enum SetPolicy {
@@ -480,7 +483,7 @@ pub enum SetPolicy {
     Memory,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Describes a [set](Set)’s flags.
 pub enum SetFlag {
@@ -495,7 +498,7 @@ pub enum SetFlag {
     Dynamic,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Describes an operator on set.
 pub enum SetOp {
@@ -505,7 +508,7 @@ pub enum SetOp {
     Update,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Manipulate element(s) in a named set.
 pub struct Element<'a> {
     /// The table’s family.
@@ -532,7 +535,7 @@ impl Default for Element<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// [Flowtables] allow you to accelerate packet forwarding in software (and in hardware if your NIC supports it)
 /// by using a conntrack-based network stack bypass.
 ///
@@ -579,7 +582,7 @@ impl Default for FlowTable<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This object represents a named [counter].
 ///
 /// A counter counts both the total number of packets and the total bytes it has seen since it was last reset.
@@ -617,7 +620,7 @@ impl Default for Counter<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This object represents a named [quota](Quota).
 ///
 /// A quota:
@@ -665,7 +668,7 @@ impl Default for Quota<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "ct helper")]
 /// Enable the specified [conntrack helper][Conntrack helpers] for this packet.
 ///
@@ -706,7 +709,7 @@ impl Default for CTHelper<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This object represents a named [limit](Limit).
 ///
 /// A limit uses a [token bucket](Token bucket) filter to match packets:
@@ -760,7 +763,7 @@ impl Default for Limit<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// A unit used in [limits](Limit).
 pub enum LimitUnit {
@@ -770,14 +773,14 @@ pub enum LimitUnit {
     Bytes,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct Meter<'a> {
     pub name: Cow<'a, str>,
     pub key: Expression<'a>,
     pub stmt: Box<Statement<'a>>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Represents the live ruleset (to be [flushed](NfCmd::Flush)).
 pub struct Ruleset {}
 
@@ -788,7 +791,7 @@ impl Default for Ruleset {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Library information in output.
 ///
 /// In output, the first object in an nftables array is a special one containing library information.
@@ -821,7 +824,7 @@ impl Default for MetainfoObject<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This object represents a named [conntrack timeout][Ct timeout] policy.
 ///
 /// You can use a ct timeout object to specify a connection tracking timeout policy for a particular flow.
@@ -867,7 +870,7 @@ impl Default for CTTimeout<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This object represents a named [conntrack expectation][Ct expectation].
 ///
 /// [Ct expectation]: <https://wiki.nftables.org/wiki-nftables/index.php/Ct_expectation>
@@ -904,7 +907,7 @@ pub struct CTExpectation<'a> {
 /// Named SynProxy requires **nftables 0.9.3 or newer**.
 ///
 /// [SynProxy]: https://wiki.nftables.org/wiki-nftables/index.php/Synproxy
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct SynProxy<'a> {
     /// The table’s family.
     pub family: NfFamily,

--- a/src/stmt.rs
+++ b/src/stmt.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use strum_macros::EnumString;
@@ -10,7 +11,7 @@ use crate::visitor::single_string_to_option_hashset_logflag;
 use crate::expr::Expression;
 use std::borrow::Cow;
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 /// Statements are the building blocks for rules. Each rule consists of at least one.
@@ -87,28 +88,28 @@ pub enum Statement<'a> {
     // TODO: secmark
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// `accept` verdict.
 pub struct Accept {}
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// `drop` verdict.
 pub struct Drop {}
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// `continue` verdict.
 pub struct Continue {}
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// `return` verdict.
 pub struct Return {}
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 pub struct JumpTarget<'a> {
     pub target: Cow<'a, str>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This matches the expression on left hand side (typically a packet header or packet meta info) with the expression on right hand side (typically a constant value).
 ///
 /// If the statement evaluates to true, the next statement in this rule is considered.
@@ -122,7 +123,7 @@ pub struct Match<'a> {
     pub op: Operator,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 /// Anonymous or named Counter.
 pub enum Counter<'a> {
@@ -132,7 +133,7 @@ pub enum Counter<'a> {
     Anonymous(Option<AnonymousCounter>),
 }
 
-#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Default, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This object represents a byte/packet counter.
 /// In input, no properties are required.
 /// If given, they act as initial values for the counter.
@@ -145,7 +146,7 @@ pub struct AnonymousCounter {
     pub bytes: Option<usize>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// This changes the packet data or meta info.
 pub struct Mangle<'a> {
     /// The packet data to be changed, given as an `exthdr`, `payload`, `meta`, `ct` or `ct helper` expression.
@@ -154,7 +155,7 @@ pub struct Mangle<'a> {
     pub value: Expression<'a>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 /// Represents an anonymous or named quota object.
 pub enum QuotaOrQuotaRef<'a> {
@@ -164,7 +165,7 @@ pub enum QuotaOrQuotaRef<'a> {
     QuotaRef(Cow<'a, str>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Creates an anonymous quota which lives in the rule it appears in.
 pub struct Quota<'a> {
     /// Quota value.
@@ -182,7 +183,7 @@ pub struct Quota<'a> {
     pub inv: Option<bool>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Creates an anonymous limit which lives in the rule it appears in.
 pub struct Limit<'a> {
     /// Rate value to limit to.
@@ -204,7 +205,7 @@ pub struct Limit<'a> {
     pub inv: Option<bool>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Forward a packet to a different destination.
 pub struct Flow<'a> {
     /// Operator on flow/set.
@@ -213,7 +214,7 @@ pub struct Flow<'a> {
     pub flowtable: Cow<'a, str>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Forward a packet to a different destination.
 pub struct FWD<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -227,7 +228,7 @@ pub struct FWD<'a> {
     pub addr: Option<Expression<'a>>,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Protocol family for `FWD`.
 pub enum FWDFamily {
@@ -235,7 +236,7 @@ pub enum FWDFamily {
     IP6,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Duplicate a packet to a different destination.
 pub struct Dup<'a> {
     /// Address to duplicate packet to.
@@ -245,7 +246,7 @@ pub struct Dup<'a> {
     pub dev: Option<Expression<'a>>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Perform Network Address Translation.
 /// Referenced by `SNAT` and `DNAT` statements.
 pub struct NAT<'a> {
@@ -263,7 +264,7 @@ pub struct NAT<'a> {
     pub flags: Option<HashSet<NATFlag>>,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Protocol family for `NAT`.
 pub enum NATFamily {
@@ -271,7 +272,7 @@ pub enum NATFamily {
     IP6,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Flags for `NAT`.
 pub enum NATFlag {
@@ -281,7 +282,7 @@ pub enum NATFlag {
     Persistent,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Reject the packet and send the given error reply.
 pub struct Reject {
     #[serde(skip_serializing_if = "Option::is_none", rename = "type")]
@@ -298,7 +299,7 @@ impl Reject {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Types of `Reject`.
 pub enum RejectType {
@@ -309,7 +310,7 @@ pub enum RejectType {
     ICMPv6,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Dynamically add/update elements to a set.
 pub struct Set<'a> {
     /// Operator on set.
@@ -320,7 +321,7 @@ pub struct Set<'a> {
     pub set: Cow<'a, str>,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Operators on `Set`.
 pub enum SetOp {
@@ -328,7 +329,7 @@ pub enum SetOp {
     Update,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Log the packet.
 /// All properties are optional.
 pub struct Log<'a> {
@@ -374,7 +375,7 @@ impl Log<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Levels of `Log`.
 pub enum LogLevel {
@@ -389,7 +390,9 @@ pub enum LogLevel {
     Audit,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, EnumString)]
+#[derive(
+    Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, EnumString, JsonSchema,
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 /// Flags of `Log`.
@@ -405,7 +408,7 @@ pub enum LogFlag {
     All,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Apply a given statement using a meter.
 pub struct Meter<'a> {
     /// Meter name.
@@ -418,7 +421,7 @@ pub struct Meter<'a> {
     pub stmt: Box<Statement<'a>>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Queue the packet to userspace.
 pub struct Queue<'a> {
     /// Queue number.
@@ -429,7 +432,7 @@ pub struct Queue<'a> {
     pub flags: Option<HashSet<QueueFlag>>,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Flags of `Queue`.
 pub enum QueueFlag {
@@ -437,7 +440,7 @@ pub enum QueueFlag {
     Fanout,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "vmap")]
 /// Apply a verdict conditionally.
 pub struct VerdictMap<'a> {
@@ -448,7 +451,7 @@ pub struct VerdictMap<'a> {
     pub data: Expression<'a>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename = "ct count")]
 /// Limit the number of connections using conntrack.
 pub struct CTCount<'a> {
@@ -460,7 +463,7 @@ pub struct CTCount<'a> {
     pub inv: Option<bool>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 /// Limit the number of connections using conntrack.
 ///
 /// Anonymous synproxy was requires **nftables 0.9.2 or newer**.
@@ -476,7 +479,7 @@ pub struct SynProxy {
     pub flags: Option<HashSet<SynProxyFlag>>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Redirects the packet to a local socket without changing the packet header in any way.
 pub struct TProxy<'a> {
@@ -487,7 +490,7 @@ pub struct TProxy<'a> {
     pub addr: Option<Cow<'a, str>>,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 /// Represents an operator for `Match`.
 pub enum Operator {
     #[serde(rename = "&")]

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,9 +1,10 @@
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// Families in nftables.
 ///
 /// See <https://wiki.nftables.org/wiki-nftables/index.php/Nftables_families>.
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 pub enum NfFamily {
     IP,
@@ -14,7 +15,7 @@ pub enum NfFamily {
     NetDev,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents the type of a Chain.
 pub enum NfChainType {
@@ -23,7 +24,7 @@ pub enum NfChainType {
     NAT,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents the policy of a Chain.
 pub enum NfChainPolicy {
@@ -31,7 +32,7 @@ pub enum NfChainPolicy {
     Drop,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents a netfilter hook.
 ///
@@ -46,7 +47,7 @@ pub enum NfHook {
     Egress,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Represents a conntrack helper protocol.
 pub enum CTHProto {
@@ -60,7 +61,7 @@ pub enum CTHProto {
     Generic,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 pub enum RejectCode {
     #[serde(rename = "admin-prohibited")]
     /// Host administratively prohibited (ICMPX, ICMP, ICMPv6)
@@ -91,7 +92,7 @@ pub enum RejectCode {
     AddrUnreach,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// Describes a SynProxy's flags.
 pub enum SynProxyFlag {
@@ -102,7 +103,7 @@ pub enum SynProxyFlag {
     SackPerm,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 /// A time unit (used by [limits][crate::schema::Limit]).
 pub enum NfTimeUnit {


### PR DESCRIPTION
Hi,
thank you for this useful project. In addition to generate JSON I'd like to export the nice and explicit Rust types to a JSON Schema to use it in other scenarios as well. This PR adds basic support for generating a schema and export it to file.

The PR introduces an additional dependency (schemars) which can generate a schema by deriving the JSONSchema macro.