### PR TITLE
ci: fix user network ns on actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -68,17 +68,9 @@ jobs:
         run: cargo test --verbose
       - name: Run tests (with netns)
         run: |
-          CARGO_BIN=$(which cargo)
-          echo "abi <abi/4.0>,
-          include <tunables/global>
+          # enable user network ns on runner
+          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 
-          profile cargo $CARGO_BIN flags=(unconfined) {
-            userns,
-
-            # Site-specific additions and overrides. See local/README for details.
-            include if exists <local/cargo>
-          }" | sudo tee /etc/apparmor.d/cargo
-          sudo service apparmor reload
           nft --version
           cargo --config \
             "target.'cfg(target_os = \"linux\")'.runner = 'unshare -rn'" \


### PR DESCRIPTION
The *Rust* Actions workflow recently failed to run the user-netns tests due to:

```
unshare: write failed /proc/self/uid_map: Operation not permitted
```

This is likely due to a recent change in the runner image.

A fix suggested [here](https://github.com/actions/runner-images/issues/10443#issuecomment-2616616457) was applied. The custom AppArmor profile is not needed anymore.