### PR TITLE
Fix clippy string format lint

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,7 +47,7 @@ fn deserialize_stdin() {
     let mut buffer = String::new();
 
     match io::stdin().read_to_string(&mut buffer) {
-        Err(error) => panic!("Problem opening the file: {:?}", error),
+        Err(error) => panic!("Problem opening the file: {error:?}"),
         Ok(_) => {
             println!("Document: {}", &buffer);
 
@@ -55,9 +55,9 @@ fn deserialize_stdin() {
             let result: Result<Nftables, _> = serde_path_to_error::deserialize(deserializer);
 
             match result {
-                Ok(_) => println!("Result: {:?}", result),
+                Ok(_) => println!("Result: {result:?}"),
                 Err(err) => {
-                    panic!("Deserialization error: {}", err);
+                    panic!("Deserialization error: {err}");
                 }
             }
         }

--- a/tests/deserialize.rs
+++ b/tests/deserialize.rs
@@ -13,7 +13,7 @@ fn test_deserialize_json_files(path: &Path) -> datatest_stable::Result<()> {
 
     match result {
         Ok(nf) => {
-            println!("Deserialized document: {:?}", nf);
+            println!("Deserialized document: {nf:?}");
             Ok(())
         }
         Err(err) => Err(serde_json::error::Error::custom(format!(

--- a/tests/serialize.rs
+++ b/tests/serialize.rs
@@ -50,6 +50,6 @@ fn test_serialize() {
 
     let j = serde_json::to_string(&_a).unwrap();
     let result: Nftables = serde_json::from_str(&j).unwrap();
-    println!("JSON: {}", j);
-    println!("Parsed: {:?}", result);
+    println!("JSON: {j}");
+    println!("Parsed: {result:?}");
 }


### PR DESCRIPTION
This is needed to unblock the [failing project CI](https://github.com/nftables-rs/nftables-rs/actions/runs/14817429009/job/41599840562#step:4:175).

Clippy in Rust nightly is strictly enforcing [clippy::uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args).