### PR TITLE
fix: bitwise flags or with more than two operands

### DIFF
--- a/resources/test/json/bitflags.json
+++ b/resources/test/json/bitflags.json
@@ -1,0 +1,132 @@
+{
+  "nftables": [
+    {
+      "metainfo": {
+        "version": "1.0.9",
+        "release_name": "Old Doc Yak #3",
+        "json_schema_version": 1
+      }
+    },
+    {
+      "table": {
+        "family": "inet",
+        "name": "filter",
+        "handle": 1
+      }
+    },
+    {
+      "chain": {
+        "family": "inet",
+        "table": "filter",
+        "name": "input",
+        "handle": 1
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "filter",
+        "chain": "input",
+        "handle": 2,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "&": [
+                  {
+                    "payload": {
+                      "protocol": "tcp",
+                      "field": "flags"
+                    }
+                  },
+                  "syn"
+                ]
+              },
+              "right": [
+                "syn",
+                "ack"
+              ]
+            }
+          },
+          {
+            "drop": null
+          }
+        ]
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "filter",
+        "chain": "input",
+        "handle": 3,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "&": [
+                  {
+                    "payload": {
+                      "protocol": "tcp",
+                      "field": "flags"
+                    }
+                  },
+                  [
+                    "fin",
+                    "syn",
+                    "rst",
+                    "ack"
+                  ]
+                ]
+              },
+              "right": "syn"
+            }
+          },
+          {
+            "drop": null
+          }
+        ]
+      }
+    },
+    {
+      "rule": {
+        "family": "inet",
+        "table": "filter",
+        "chain": "input",
+        "handle": 4,
+        "expr": [
+          {
+            "match": {
+              "op": "==",
+              "left": {
+                "&": [
+                  {
+                    "payload": {
+                      "protocol": "tcp",
+                      "field": "flags"
+                    }
+                  },
+                  [
+                    "fin",
+                    "syn",
+                    "rst",
+                    "ack"
+                  ]
+                ]
+              },
+              "right": [
+                "syn",
+                "ack"
+              ]
+            }
+          },
+          {
+            "drop": null
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/resources/test/nft/bitflags.nft
+++ b/resources/test/nft/bitflags.nft
@@ -1,0 +1,12 @@
+#!/sbin/nft -f
+
+flush ruleset
+
+table inet filter {
+
+	chain input {
+	     tcp flags and syn == syn|ack drop
+	     tcp flags and (syn|ack|fin|rst) == syn drop
+	     tcp flags and (syn|ack|fin|rst) == syn|ack drop
+	}
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -643,7 +643,7 @@ pub enum BinaryOperation<'a> {
 
     #[serde(rename = "|")]
     /// Binary OR (`|`)
-    OR(Expression<'a>, Expression<'a>),
+    OR(Vec<Expression<'a>>),
 
     #[serde(rename = "^")]
     /// Binary XOR (`^`)


### PR DESCRIPTION
Fixes #165
- changed BinaryOperation::OR to accept Vec<Expression> instead of exactly two.
- added regression test (tests/test_bit_flags)
- note: The fix was tested with deserialization only. I did not test adding an nftables rule with bit flags