### PR TITLE
Add `derive_builder` and `derive_new` to relevant structs and enums.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,6 +302,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "datatest-stable"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +346,48 @@ dependencies = [
  "fancy-regex",
  "libtest-mimic",
  "walkdir",
+]
+
+[[package]]
+name = "derive-new"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cdc8d50f426189eef89dac62fabfa0abb27d5cc008f25bf4156a0203325becc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -372,6 +449,12 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "futures"
@@ -494,6 +577,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,6 +672,8 @@ version = "0.6.2"
 dependencies = [
  "async-process",
  "datatest-stable",
+ "derive-new",
+ "derive_builder",
  "futures-lite",
  "schemars",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,8 @@ exclude = [
 
 [dependencies]
 async-process = { version = "2.3.0", optional = true }
+derive-new = "0.7.0"
+derive_builder = "0.20.2"
 futures-lite = { version = "2.6.0", optional = true }
 schemars = "0.9.0"
 serde = { version = "1.0.219", features = ["derive"] }

--- a/src/batch.rs
+++ b/src/batch.rs
@@ -1,25 +1,15 @@
+use derive_new::new;
 use serde::{Deserialize, Serialize};
 
 use crate::schema::{NfCmd, NfListObject, NfObject, Nftables};
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, Default, new)]
 /// Batch manages nftables objects and is used to prepare an nftables payload.
 pub struct Batch<'a> {
     data: Vec<NfObject<'a>>,
 }
 
-impl Default for Batch<'_> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<'a> Batch<'a> {
-    /// Creates an empty Batch instance.
-    pub fn new() -> Batch<'a> {
-        Batch { data: Vec::new() }
-    }
-
     /// Adds object with `add` command to Batch.
     pub fn add(&mut self, obj: NfListObject<'a>) {
         self.data.push(NfObject::CmdObject(NfCmd::Add(obj)))

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,7 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum NftablesError {
+    #[error(transparent)]
+    BuilderError(#[from] derive_builder::UninitializedFieldError)
+}

--- a/src/expr.rs
+++ b/src/expr.rs
@@ -1,22 +1,25 @@
+use derive_builder::Builder;
+use derive_new::new;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{borrow::Cow, collections::HashSet};
 
-use crate::stmt::{Counter, JumpTarget, Statement};
+use crate::{stmt::{Counter, JumpTarget, Statement}, error::NftablesError};
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(untagged)]
 /// Expressions are the building blocks of (most) [statements](crate::stmt::Statement).
 /// In their most basic form, they are just immediate values represented as a
 /// JSON string, integer or boolean type.
 pub enum Expression<'a> {
+    #[new(into)]
     // immediates
     /// A string expression (*immediate expression*).
     /// For string expressions there are two special cases:
     ///   * `@STRING`: The remaining part is taken as [set](crate::schema::Set)
     ///     name to create a set reference.
     ///   * `\*`: Construct a wildcard expression.
-    String(Cow<'a, str>),
+    String(#[new(into)] Cow<'a, str>),
     /// An integer expression (*immediate expression*).
     Number(u32),
     /// A boolean expression (*immediate expression*).
@@ -24,11 +27,11 @@ pub enum Expression<'a> {
     /// List expressions are constructed by plain arrays containing of an arbitrary number of expressions.
     List(Vec<Expression<'a>>),
     /// A [binary operation](BinaryOperation) expression.
-    BinaryOperation(Box<BinaryOperation<'a>>),
+    BinaryOperation(#[new(into)] Box<BinaryOperation<'a>>),
     /// Construct a range of values.
     ///
     /// The first array item denotes the lower boundary, the second one the upper boundary.
-    Range(Box<Range<'a>>),
+    Range(#[new(into)] Box<Range<'a>>),
 
     /// Wrapper for non-immediate expressions.
     Named(NamedExpression<'a>),
@@ -36,7 +39,7 @@ pub enum Expression<'a> {
     Verdict(Verdict<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Wrapper for non-immediate [Expressions](Expression).
 pub enum NamedExpression<'a> {
@@ -46,7 +49,7 @@ pub enum NamedExpression<'a> {
     /// For mappings, an array of arrays with exactly two elements is expected.
     Set(Vec<SetItem<'a>>),
     /// Map a key to a value.
-    Map(Box<Map<'a>>),
+    Map(#[new(into)] Box<Map<'a>>),
     /// Construct an IPv4 or IPv6 [prefix](Prefix) consisting of address part and prefix length.
     Prefix(Prefix<'a>),
 
@@ -89,7 +92,8 @@ pub enum NamedExpression<'a> {
     Osf(Osf<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "map")]
 /// Map a key to a value.
 pub struct Map<'a> {
@@ -109,7 +113,7 @@ impl Default for Map<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(untagged)]
 /// Item in an anonymous set.
 pub enum SetItem<'a> {
@@ -121,18 +125,21 @@ pub enum SetItem<'a> {
     MappingStatement(Expression<'a>, Statement<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "prefix")]
 /// Construct an IPv4 or IPv6 prefix consisting of address part in
 /// [addr](Prefix::addr) and prefix length in [len](Prefix::len).
 pub struct Prefix<'a> {
+    #[new(into)]
     /// An IPv4 or IPv6 address.
     pub addr: Box<Expression<'a>>,
     /// The prefix length.
     pub len: u32,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "range")]
 /// Construct a range of values.
 /// The first array item denotes the lower boundary, the second one the upper
@@ -145,7 +152,7 @@ pub struct Range<'a> {
     pub range: [Expression<'a>; 2],
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(untagged)]
 /// Construct a payload expression, i.e. a reference to a certain part of packet
 /// data.
@@ -157,7 +164,8 @@ pub enum Payload<'a> {
     PayloadRaw(PayloadRaw),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// Creates a raw payload expression to point at a random number
 /// ([len](PayloadRaw::len)) of bits at a certain offset
 /// ([offset](PayloadRaw::offset)) from a given reference point
@@ -182,15 +190,18 @@ impl Default for PayloadRaw {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// Construct a payload expression, i.e. a reference to a certain part of packet
 /// data.
 ///
 /// Allows to reference a field by name ([field](PayloadField::field)) in a
 /// named packet header ([protocol](PayloadField::protocol)).
 pub struct PayloadField<'a> {
+    #[new(into)]
     /// A named packet header.
     pub protocol: Cow<'a, str>,
+    #[new(into)]
     /// The field name.
     pub field: Cow<'a, str>,
 }
@@ -205,7 +216,7 @@ impl Default for PayloadField<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Represents a protocol layer for [payload](Payload) references.
 pub enum PayloadBase {
@@ -223,15 +234,18 @@ pub enum PayloadBase {
     IH,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "exthdr")]
 /// Create a reference to a field ([field](Exthdr::field)) in an IPv6 extension
 /// header ([name](Exthdr::name)).
 ///
 /// [offset](Exthdr::offset) is used only for `rt0` protocol.
 pub struct Exthdr<'a> {
+    #[new(into)]
     /// The IPv6 extension header name.
     pub name: Cow<'a, str>,
+    #[new(into)]
     /// The field name.
     ///
     /// If the [field][Exthdr::field] property is not given, the expression is
@@ -254,13 +268,16 @@ impl Default for Exthdr<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "tcp option")]
 /// Create a reference to a field ([field](TcpOption::field)) of a TCP option
 /// header ([name](TcpOption::field)).
 pub struct TcpOption<'a> {
+    #[new(into)]
     /// The TCP option header name.
     pub name: Cow<'a, str>,
+    #[new(into)]
     /// The field name.
     ///
     /// If the field property is not given, the expression is to be used as a
@@ -280,13 +297,16 @@ impl Default for TcpOption<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "sctp chunk")]
 /// Create a reference to a field ([field](SctpChunk::field)) of an SCTP chunk
 /// ((name)[SctpChunk::name]).
 pub struct SctpChunk<'a> {
+    #[new(into)]
     /// The SCTP chunk name.
     pub name: Cow<'a, str>,
+    #[new(into)]
     /// The field name.
     ///
     /// If the field property is not given, the expression is to be used as an
@@ -296,7 +316,8 @@ pub struct SctpChunk<'a> {
     pub field: Cow<'a, str>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "meta")]
 /// Create a reference to packet meta data.
 ///
@@ -316,7 +337,7 @@ impl Default for Meta {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Represents a `meta` key for packet meta data.
 ///
@@ -396,7 +417,8 @@ pub enum MetaKey {
     Nftrace,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "rt")]
 /// Create a reference to packet routing data.
 pub struct RT {
@@ -419,7 +441,7 @@ impl Default for RT {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Represents a key to reference to packet routing data.
 pub enum RTKey {
@@ -431,7 +453,7 @@ pub enum RTKey {
     MTU,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Represents a protocol family for use by the [rt](RT) expression.
 pub enum RTFamily {
@@ -441,10 +463,12 @@ pub enum RTFamily {
     IP6,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "ct")]
 /// Create a reference to packet conntrack data.
 pub struct CT<'a> {
+    #[new(into)]
     /// The conntrack expression.
     ///
     /// See also: *CONNTRACK EXPRESSIONS* in *ntf(8)*.
@@ -471,7 +495,7 @@ impl Default for CT<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Represents a protocol family for use by the [ct](CT) expression.
 pub enum CTFamily {
@@ -481,7 +505,7 @@ pub enum CTFamily {
     IP6,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Represents a direction for use by the [ct](CT) expression.
 pub enum CTDir {
@@ -491,7 +515,8 @@ pub enum CTDir {
     Reply,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "numgen")]
 /// Create a number generator.
 pub struct Numgen {
@@ -517,7 +542,7 @@ impl Default for Numgen {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Represents a number generator mode.
 pub enum NgMode {
@@ -527,7 +552,8 @@ pub enum NgMode {
     Random,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "jhash")]
 /// Hash packet data (Jenkins Hash).
 pub struct JHash<'a> {
@@ -537,6 +563,7 @@ pub struct JHash<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     /// Increment the returned value by a fixed offset.
     pub offset: Option<u32>,
+    #[new(into)]
     /// Determines the parameters of the packet header to apply the hashing,
     /// concatenations are possible as well.
     pub expr: Box<Expression<'a>>,
@@ -562,7 +589,8 @@ impl Default for JHash<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "symhash")]
 /// Hash packet data (Symmetric Hash).
 pub struct SymHash {
@@ -583,7 +611,8 @@ impl Default for SymHash {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "fib")]
 /// Perform kernel Forwarding Information Base lookups.
 pub struct Fib {
@@ -606,7 +635,7 @@ impl Default for Fib {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Represents which data is queried by [fib](Fib) lookup.
 pub enum FibResult {
@@ -618,7 +647,7 @@ pub enum FibResult {
     Type,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize, Deserialize, Hash, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Represents flags for `fib` lookup.
 pub enum FibFlag {
@@ -634,7 +663,7 @@ pub enum FibFlag {
     Oif,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 /// Represents a binary operation to be used in an `Expression`.
 pub enum BinaryOperation<'a> {
     #[serde(rename = "&")]
@@ -658,7 +687,7 @@ pub enum BinaryOperation<'a> {
     RSHIFT(Expression<'a>, Expression<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// A verdict expression (used in [verdict maps](crate::stmt::VerdictMap)).
 ///
@@ -703,13 +732,15 @@ pub enum Verdict<'a> {
     Goto(JumpTarget<'a>),
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "elem")]
 /// Explicitly set element object.
 ///
 /// Element-related commands allow one to change contents of named
 /// [sets](crate::schema::Set) and [maps](crate::schema::Map).
 pub struct Elem<'a> {
+    #[new(into)]
     /// The element value.
     pub val: Box<Expression<'a>>,
     /// Timeout value for [sets](crate::schema::Set)/[maps](crate::schema::Map).
@@ -717,6 +748,7 @@ pub struct Elem<'a> {
     pub timeout: Option<u32>,
     /// The time until given element expires, useful for ruleset replication only.
     pub expires: Option<u32>,
+    #[new(into)]
     /// Per element comment field.
     pub comment: Option<Cow<'a, str>>,
     /// Enable a [counter][crate::stmt::Counter] per element.
@@ -738,10 +770,12 @@ impl Default for Elem<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "socket")]
 /// Construct a reference to packet’s socket.
 pub struct Socket<'a> {
+    #[new(into)]
     /// The socket attribute to match on.
     pub key: Cow<'a, SocketAttr>,
 }
@@ -755,7 +789,7 @@ impl Default for Socket<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// A [socket][Socket] attribute to match on.
 pub enum SocketAttr {
@@ -769,13 +803,15 @@ pub enum SocketAttr {
     Cgroupv2,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "osf")]
 /// Perform OS fingerprinting.
 ///
 /// This expression is typically used in the [LHS](crate::stmt::Match::left) of
 /// a [match](crate::stmt::Match) statement.
 pub struct Osf<'a> {
+    #[new(into)]
     /// Name of the OS signature to match.
     ///
     /// All signatures can be found at `pf.os` file.
@@ -785,7 +821,7 @@ pub struct Osf<'a> {
     pub ttl: OsfTtl,
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// TTL check mode for [osf](Osf).
 pub enum OsfTtl {

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -23,7 +23,7 @@ compile_error!("features `tokio` and `async-process` are mutually exclusive");
 
 /// Error during `nft` execution.
 #[derive(Error, Debug)]
-pub enum NftablesError {
+pub enum NftExecutableError {
     #[error("unable to execute {program:?}: {inner}")]
     NftExecution { program: OsString, inner: io::Error },
     #[error("{program:?}'s output contained invalid utf8: {inner}")]
@@ -45,7 +45,7 @@ pub enum NftablesError {
 /// Get the rule set that is currently active in the kernel.
 ///
 /// This is done by calling the default `nft` executable with default arguments.
-pub fn get_current_ruleset() -> Result<Nftables<'static>, NftablesError> {
+pub fn get_current_ruleset() -> Result<Nftables<'static>, NftExecutableError> {
     get_current_ruleset_with_args(DEFAULT_NFT, DEFAULT_ARGS)
 }
 
@@ -62,14 +62,14 @@ pub fn get_current_ruleset() -> Result<Nftables<'static>, NftablesError> {
 pub fn get_current_ruleset_with_args<'a, P, A, I>(
     program: Option<&P>,
     args: I,
-) -> Result<Nftables<'static>, NftablesError>
+) -> Result<Nftables<'static>, NftExecutableError>
 where
     P: AsRef<OsStr> + ?Sized,
     A: AsRef<OsStr> + ?Sized + 'a,
     I: IntoIterator<Item = &'a A> + 'a,
 {
     let output = get_current_ruleset_raw(program, args)?;
-    serde_json::from_str(&output).map_err(NftablesError::NftInvalidJson)
+    serde_json::from_str(&output).map_err(NftExecutableError::NftInvalidJson)
 }
 
 /// Get the current raw rule set json by calling a custom `nft` with custom arguments.
@@ -85,7 +85,7 @@ where
 pub fn get_current_ruleset_raw<'a, P, A, I>(
     program: Option<&P>,
     args: I,
-) -> Result<String, NftablesError>
+) -> Result<String, NftExecutableError>
 where
     P: AsRef<OsStr> + ?Sized,
     A: AsRef<OsStr> + ?Sized + 'a,
@@ -102,7 +102,7 @@ where
         None => nft_cmd.args(["list", "ruleset"]),
     };
     let process_result = nft_cmd.output();
-    let process_result = process_result.map_err(|e| NftablesError::NftExecution {
+    let process_result = process_result.map_err(|e| NftExecutableError::NftExecution {
         inner: e,
         program: program.into(),
     })?;
@@ -112,7 +112,7 @@ where
     if !process_result.status.success() {
         let stderr = read_output(program, process_result.stderr)?;
 
-        return Err(NftablesError::NftFailed {
+        return Err(NftExecutableError::NftFailed {
             program: program.into(),
             hint: "getting the current ruleset".to_string(),
             stdout,
@@ -126,7 +126,7 @@ where
 ///
 /// See the synchronous [`get_current_ruleset`] for more information.
 #[cfg(any(feature = "tokio", feature = "async-process"))]
-pub async fn get_current_ruleset_async() -> Result<Nftables<'static>, NftablesError> {
+pub async fn get_current_ruleset_async() -> Result<Nftables<'static>, NftExecutableError> {
     get_current_ruleset_with_args_async(DEFAULT_NFT, DEFAULT_ARGS).await
 }
 
@@ -137,14 +137,14 @@ pub async fn get_current_ruleset_async() -> Result<Nftables<'static>, NftablesEr
 pub async fn get_current_ruleset_with_args_async<'a, P, A, I>(
     program: Option<&P>,
     args: I,
-) -> Result<Nftables<'static>, NftablesError>
+) -> Result<Nftables<'static>, NftExecutableError>
 where
     P: AsRef<OsStr> + ?Sized,
     A: AsRef<OsStr> + ?Sized + 'a,
     I: IntoIterator<Item = &'a A> + 'a,
 {
     let output = get_current_ruleset_raw_async(program, args).await?;
-    serde_json::from_str(&output).map_err(NftablesError::NftInvalidJson)
+    serde_json::from_str(&output).map_err(NftExecutableError::NftInvalidJson)
 }
 
 /// Get the current raw rule set json asynchronously by calling a custom `nft` with custom arguments.
@@ -154,7 +154,7 @@ where
 pub async fn get_current_ruleset_raw_async<'a, P, A, I>(
     program: Option<&P>,
     args: I,
-) -> Result<String, NftablesError>
+) -> Result<String, NftExecutableError>
 where
     P: AsRef<OsStr> + ?Sized,
     A: AsRef<OsStr> + ?Sized + 'a,
@@ -176,7 +176,7 @@ where
         None => nft_cmd.args(["list", "ruleset"]),
     };
     let process_result = nft_cmd.output().await;
-    let process_result = process_result.map_err(|e| NftablesError::NftExecution {
+    let process_result = process_result.map_err(|e| NftExecutableError::NftExecution {
         inner: e,
         program: program.into(),
     })?;
@@ -186,7 +186,7 @@ where
     if !process_result.status.success() {
         let stderr = read_output(program, process_result.stderr)?;
 
-        return Err(NftablesError::NftFailed {
+        return Err(NftExecutableError::NftFailed {
             program: program.into(),
             hint: "getting the current ruleset".to_string(),
             stdout,
@@ -199,7 +199,7 @@ where
 /// Apply the given rule set to the kernel.
 ///
 /// This is done by calling the default `nft` executable with default arguments.
-pub fn apply_ruleset(nftables: &Nftables) -> Result<(), NftablesError> {
+pub fn apply_ruleset(nftables: &Nftables) -> Result<(), NftExecutableError> {
     apply_ruleset_with_args(nftables, DEFAULT_NFT, DEFAULT_ARGS)
 }
 
@@ -215,7 +215,7 @@ pub fn apply_ruleset_with_args<'a, P, A, I>(
     nftables: &Nftables,
     program: Option<&P>,
     args: I,
-) -> Result<(), NftablesError>
+) -> Result<(), NftExecutableError>
 where
     P: AsRef<OsStr> + ?Sized,
     A: AsRef<OsStr> + ?Sized + 'a,
@@ -231,7 +231,7 @@ where
 ///
 /// This is done by using `nft --echo`. One can get rule handles from the returned
 /// objects for future modifications, positional inserts, as well as removal.
-pub fn apply_and_return_ruleset(nftables: &Nftables) -> Result<Nftables<'static>, NftablesError> {
+pub fn apply_and_return_ruleset(nftables: &Nftables) -> Result<Nftables<'static>, NftExecutableError> {
     apply_and_return_ruleset_with_args(nftables, DEFAULT_NFT, DEFAULT_ARGS)
 }
 
@@ -244,7 +244,7 @@ pub fn apply_and_return_ruleset_with_args<'a, P, A, I>(
     nftables: &Nftables,
     program: Option<&P>,
     args: I,
-) -> Result<Nftables<'static>, NftablesError>
+) -> Result<Nftables<'static>, NftExecutableError>
 where
     P: AsRef<OsStr> + ?Sized,
     A: AsRef<OsStr> + ?Sized + 'a,
@@ -256,7 +256,7 @@ where
         .map(AsRef::as_ref)
         .chain(Some("--echo".as_ref()));
     let output = apply_ruleset_raw(&nftables, program, args)?;
-    serde_json::from_str(&output).map_err(NftablesError::NftInvalidJson)
+    serde_json::from_str(&output).map_err(NftExecutableError::NftInvalidJson)
 }
 
 /// Apply the given raw rule set json by calling a custom `nft` with custom arguments.
@@ -273,7 +273,7 @@ pub fn apply_ruleset_raw<'a, P, A, I>(
     payload: &str,
     program: Option<&P>,
     args: I,
-) -> Result<String, NftablesError>
+) -> Result<String, NftExecutableError>
 where
     P: AsRef<OsStr> + ?Sized,
     A: AsRef<OsStr> + ?Sized + 'a,
@@ -290,7 +290,7 @@ where
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn();
-    let mut process = process.map_err(|e| NftablesError::NftExecution {
+    let mut process = process.map_err(|e| NftExecutableError::NftExecution {
         program: program.into(),
         inner: e,
     })?;
@@ -298,7 +298,7 @@ where
     let mut stdin = process.stdin.take().unwrap();
     stdin
         .write_all(payload.as_bytes())
-        .map_err(|e| NftablesError::NftExecution {
+        .map_err(|e| NftExecutableError::NftExecution {
             program: program.into(),
             inner: e,
         })?;
@@ -311,14 +311,14 @@ where
             let stdout = read_output(program, process_result.stdout)?;
             let stderr = read_output(program, process_result.stderr)?;
 
-            Err(NftablesError::NftFailed {
+            Err(NftExecutableError::NftFailed {
                 program: program.into(),
                 hint: "applying ruleset".to_string(),
                 stdout,
                 stderr,
             })
         }
-        Err(e) => Err(NftablesError::NftExecution {
+        Err(e) => Err(NftExecutableError::NftExecution {
             program: program.into(),
             inner: e,
         }),
@@ -329,7 +329,7 @@ where
 ///
 /// See the synchronous [`apply_ruleset`] for more information.
 #[cfg(any(feature = "tokio", feature = "async-process"))]
-pub async fn apply_ruleset_async(nftables: &Nftables<'_>) -> Result<(), NftablesError> {
+pub async fn apply_ruleset_async(nftables: &Nftables<'_>) -> Result<(), NftExecutableError> {
     apply_ruleset_with_args_async(nftables, DEFAULT_NFT, DEFAULT_ARGS).await
 }
 
@@ -341,7 +341,7 @@ pub async fn apply_ruleset_with_args_async<'a, P, A, I>(
     nftables: &Nftables<'_>,
     program: Option<&P>,
     args: I,
-) -> Result<(), NftablesError>
+) -> Result<(), NftExecutableError>
 where
     P: AsRef<OsStr> + ?Sized,
     A: AsRef<OsStr> + ?Sized + 'a,
@@ -359,7 +359,7 @@ where
 #[cfg(any(feature = "tokio", feature = "async-process"))]
 pub async fn apply_and_return_ruleset_async(
     nftables: &Nftables<'_>,
-) -> Result<Nftables<'static>, NftablesError> {
+) -> Result<Nftables<'static>, NftExecutableError> {
     apply_and_return_ruleset_with_args_async(nftables, DEFAULT_NFT, DEFAULT_ARGS).await
 }
 
@@ -372,7 +372,7 @@ pub async fn apply_and_return_ruleset_with_args_async<'a, P, A, I>(
     nftables: &Nftables<'_>,
     program: Option<&P>,
     args: I,
-) -> Result<Nftables<'static>, NftablesError>
+) -> Result<Nftables<'static>, NftExecutableError>
 where
     P: AsRef<OsStr> + ?Sized,
     A: AsRef<OsStr> + ?Sized + 'a,
@@ -384,7 +384,7 @@ where
         .map(AsRef::as_ref)
         .chain(Some("--echo".as_ref()));
     let output = apply_ruleset_raw_async(&nftables, program, args).await?;
-    serde_json::from_str(&output).map_err(NftablesError::NftInvalidJson)
+    serde_json::from_str(&output).map_err(NftExecutableError::NftInvalidJson)
 }
 
 /// Apply the given raw rule set json asynchronously by calling a custom `nft` with custom arguments.
@@ -395,7 +395,7 @@ pub async fn apply_ruleset_raw_async<'a, P, A, I>(
     payload: &str,
     program: Option<&P>,
     args: I,
-) -> Result<String, NftablesError>
+) -> Result<String, NftExecutableError>
 where
     P: AsRef<OsStr> + ?Sized,
     A: AsRef<OsStr> + ?Sized + 'a,
@@ -421,7 +421,7 @@ where
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .spawn();
-    let mut process = process.map_err(|e| NftablesError::NftExecution {
+    let mut process = process.map_err(|e| NftExecutableError::NftExecution {
         program: program.into(),
         inner: e,
     })?;
@@ -430,7 +430,7 @@ where
     stdin
         .write_all(payload.as_bytes())
         .await
-        .map_err(|e| NftablesError::NftExecution {
+        .map_err(|e| NftExecutableError::NftExecution {
             program: program.into(),
             inner: e,
         })?;
@@ -446,22 +446,22 @@ where
             let stdout = read_output(program, process_result.stdout)?;
             let stderr = read_output(program, process_result.stderr)?;
 
-            Err(NftablesError::NftFailed {
+            Err(NftExecutableError::NftFailed {
                 program: program.into(),
                 hint: "applying ruleset".to_string(),
                 stdout,
                 stderr,
             })
         }
-        Err(e) => Err(NftablesError::NftExecution {
+        Err(e) => Err(NftExecutableError::NftExecution {
             program: program.into(),
             inner: e,
         }),
     }
 }
 
-fn read_output(program: impl Into<OsString>, bytes: Vec<u8>) -> Result<String, NftablesError> {
-    String::from_utf8(bytes).map_err(|e| NftablesError::NftOutputEncoding {
+fn read_output(program: impl Into<OsString>, bytes: Vec<u8>) -> Result<String, NftExecutableError> {
+    String::from_utf8(bytes).map_err(|e| NftExecutableError::NftOutputEncoding {
         inner: e,
         program: program.into(),
     })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@ pub mod visitor;
 /// Contains handling and parsing of command line arguments.
 pub mod cli;
 
+/// Contains error types.
+pub mod error;
+
 // Default values for Default implementations.
 const DEFAULT_FAMILY: types::NfFamily = types::NfFamily::INet;
 const DEFAULT_TABLE: &str = "filter";

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,8 +1,10 @@
+use derive_builder::Builder;
+use derive_new::new;
 use schemars::JsonSchema;
 use std::{borrow::Cow, collections::HashSet};
 
 use crate::{
-    expr::Expression, stmt::Statement, types::*, visitor::single_string_to_option_vec,
+    expr::Expression, stmt::Statement, types::*, visitor::single_string_to_option_vec, error::NftablesError,
     DEFAULT_CHAIN, DEFAULT_FAMILY, DEFAULT_TABLE,
 };
 
@@ -10,19 +12,21 @@ use serde::{Deserialize, Serialize};
 
 use strum_macros::EnumString;
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// In general, any JSON input or output is enclosed in an object with a single property named **nftables**.
 ///
 /// See [libnftables-json global structure](Global Structure).
 ///
 /// (Global Structure): <https://manpages.debian.org/testing/libnftables1/libnftables-json.5.en.html#GLOBAL_STRUCTURE>
 pub struct Nftables<'a> {
-    /// An array containing [commands](NfCmd) (for input) or [ruleset elements](NfListObject) (for output).
+    #[new(into)]
     #[serde(rename = "nftables")]
+    /// An array containing [commands](NfCmd) (for input) or [ruleset elements](NfListObject) (for output).
     pub objects: Cow<'a, [NfObject<'a>]>,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(untagged)]
 /// A [ruleset element](NfListObject) or [command](NfCmd) in an [nftables document](Nftables).
 pub enum NfObject<'a> {
@@ -32,7 +36,7 @@ pub enum NfObject<'a> {
     ListObject(NfListObject<'a>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// A ruleset element in an [nftables document](Nftables).
 pub enum NfListObject<'a> {
@@ -43,9 +47,9 @@ pub enum NfListObject<'a> {
     /// A rule element.
     Rule(Rule<'a>),
     /// A set element.
-    Set(Box<Set<'a>>),
+    Set(#[new(into)] Box<Set<'a>>),
     /// A map element.
-    Map(Box<Map<'a>>),
+    Map(#[new(into)] Box<Map<'a>>),
     /// An element manipulation.
     Element(Element<'a>),
     /// A flow table.
@@ -71,7 +75,7 @@ pub enum NfListObject<'a> {
     SynProxy(SynProxy<'a>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// A command is an object with a single property whose name identifies the command.
 ///
@@ -118,21 +122,21 @@ pub enum NfCmd<'a> {
     Rename(Chain<'a>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Reset state in suitable objects, i.e. zero their internal counter.
 pub enum ResetObject<'a> {
     /// A counter to reset.
     Counter(Counter<'a>),
     /// A list of counters to reset.
-    Counters(Cow<'a, [Counter<'a>]>),
+    Counters(#[new(into)] Cow<'a, [Counter<'a>]>),
     /// A quota to reset.
     Quota(Quota<'a>),
     /// A list of quotas to reset.
-    Quotas(Cow<'a, [Quota<'a>]>),
+    Quotas(#[new(into)] Cow<'a, [Quota<'a>]>),
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Empty contents in given object, e.g. remove all chains from given table or remove all elements from given set.
 pub enum FlushObject<'a> {
@@ -141,9 +145,9 @@ pub enum FlushObject<'a> {
     /// A chain to flush (i.e., remove all rules from chain).
     Chain(Chain<'a>),
     /// A set to flush (i.e., remove all elements from set).
-    Set(Box<Set<'a>>),
+    Set(#[new(into)] Box<Set<'a>>),
     /// A map to flush (i.e., remove all elements from map).
-    Map(Box<Map<'a>>),
+    Map(#[new(into)] Box<Map<'a>>),
     /// A meter to flush.
     Meter(Meter<'a>),
     /// Flush the live ruleset (i.e., remove all elements from live ruleset).
@@ -152,11 +156,13 @@ pub enum FlushObject<'a> {
 
 // Ruleset Elements
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// This object describes a table.
 pub struct Table<'a> {
     /// The table’s [family](NfFamily), e.g. "ip" or "ip6".
     pub family: NfFamily,
+    #[new(into)]
     /// The table’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -178,16 +184,20 @@ impl Default for Table<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// This object describes a chain.
 pub struct Chain<'a> {
     /// The table’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The table’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The chain’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// New name of the chain when supplied to the [rename command](NfCmd::Rename).
     pub newname: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -213,6 +223,7 @@ pub struct Chain<'a> {
     /// (Base chains): <https://wiki.nftables.org/wiki-nftables/index.php/Configuring_chains#Adding_base_chains>
     pub prio: Option<i32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// The chain’s bound interface (if in the netdev family).
     /// Required for [base chains](Base chains).
     ///
@@ -244,7 +255,8 @@ impl Default for Chain<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// This object describes a rule.
 ///
 /// Basic building blocks of rules are statements.
@@ -252,10 +264,13 @@ impl Default for Chain<'_> {
 pub struct Rule<'a> {
     /// The table’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The table’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The chain’s name.
     pub chain: Cow<'a, str>,
+    #[new(into)]
     /// An array of statements this rule consists of.
     ///
     /// In input, it is used in [add](NfCmd::Add)/[insert](NfCmd::Insert)/[replace](NfCmd::Replace) commands only.
@@ -272,6 +287,7 @@ pub struct Rule<'a> {
     /// It is used as an alternative to **handle** then.
     pub index: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// Optional rule comment.
     pub comment: Option<Cow<'a, str>>,
 }
@@ -291,13 +307,16 @@ impl Default for Rule<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// Named set that holds expression elements.
 pub struct Set<'a> {
     /// The table’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The table’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The set’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -315,6 +334,7 @@ pub struct Set<'a> {
     /// The set’s flags.
     pub flags: Option<HashSet<SetFlag>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// Initial set element(s).
     ///
     /// A single set element might be given as string, integer or boolean value for simple cases. If additional properties are required, a formal elem object may be used.
@@ -330,6 +350,7 @@ pub struct Set<'a> {
     /// Maximum number of elements supported.
     pub size: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// Optional set comment.
     ///
     /// Set comment attribute requires at least nftables 0.9.7 and kernel 5.10
@@ -356,14 +377,17 @@ impl Default for Set<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// Named map that holds expression elements.
 /// Maps are a special form of sets in that they translate a unique key to a value.
 pub struct Map<'a> {
     /// The table’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The table’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The map’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -384,6 +408,7 @@ pub struct Map<'a> {
     /// The map’s flags.
     pub flags: Option<HashSet<SetFlag>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// Initial map set element(s).
     ///
     /// A single set element might be given as string, integer or boolean value for simple cases. If additional properties are required, a formal elem object may be used.
@@ -399,6 +424,7 @@ pub struct Map<'a> {
     /// Maximum number of elements supported.
     pub size: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// Optional map comment.
     ///
     /// The map/set comment attribute requires at least nftables 0.9.7 and kernel 5.10
@@ -426,7 +452,7 @@ impl Default for Map<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, new)]
 #[serde(untagged)]
 /// Wrapper for single or concatenated set types.
 /// The set type might be a string, such as `"ipv4_addr"` or an array consisting of strings (for concatenated types).
@@ -434,7 +460,7 @@ pub enum SetTypeValue<'a> {
     /// Single set type.
     Single(SetType),
     /// Concatenated set types.
-    Concatenated(Cow<'a, [SetType]>),
+    Concatenated(#[new(into)] Cow<'a, [SetType]>),
 }
 
 #[derive(
@@ -473,7 +499,7 @@ pub enum SetType {
     Ifname,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Describes a set’s policy.
 pub enum SetPolicy {
@@ -483,7 +509,7 @@ pub enum SetPolicy {
     Memory,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, JsonSchema)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Hash, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Describes a [set](Set)’s flags.
 pub enum SetFlag {
@@ -498,7 +524,7 @@ pub enum SetFlag {
     Dynamic,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// Describes an operator on set.
 pub enum SetOp {
@@ -508,15 +534,19 @@ pub enum SetOp {
     Update,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// Manipulate element(s) in a named set.
 pub struct Element<'a> {
     /// The table’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The table’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The set’s name.
     pub name: Cow<'a, str>,
+    #[new(into)]
     /// A single set element might be given as string, integer or boolean value for simple cases.
     /// If additional properties are required, a formal `elem` object may be used.
     /// Multiple elements may be given in an array.
@@ -535,7 +565,8 @@ impl Default for Element<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// [Flowtables] allow you to accelerate packet forwarding in software (and in hardware if your NIC supports it)
 /// by using a conntrack-based network stack bypass.
 ///
@@ -543,8 +574,10 @@ impl Default for Element<'_> {
 pub struct FlowTable<'a> {
     /// The [table](Table)’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The [table](Table)’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The flow table’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -560,6 +593,7 @@ pub struct FlowTable<'a> {
         skip_serializing_if = "Option::is_none",
         deserialize_with = "single_string_to_option_vec"
     )]
+    #[new(into)]
     /// The *devices* are specified as iifname(s) of the input interface(s) of the traffic that should be offloaded.
     ///
     /// Devices are required for both traffic directions.
@@ -582,7 +616,8 @@ impl Default for FlowTable<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// This object represents a named [counter].
 ///
 /// A counter counts both the total number of packets and the total bytes it has seen since it was last reset.
@@ -592,8 +627,10 @@ impl Default for FlowTable<'_> {
 pub struct Counter<'a> {
     /// The [table](Table)’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The [table](Table)’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The counter’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -620,7 +657,8 @@ impl Default for Counter<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// This object represents a named [quota](Quota).
 ///
 /// A quota:
@@ -635,8 +673,10 @@ impl Default for Counter<'_> {
 pub struct Quota<'a> {
     /// The [table](Table)’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The [table](Table)’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The quota’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -668,7 +708,8 @@ impl Default for Quota<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 #[serde(rename = "ct helper")]
 /// Enable the specified [conntrack helper][Conntrack helpers] for this packet.
 ///
@@ -676,20 +717,25 @@ impl Default for Quota<'_> {
 pub struct CTHelper<'a> {
     /// The [table](Table)’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The [table](Table)’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The ct helper’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The ct helper’s handle. In input, it is used by the [delete command](NfCmd::Delete) only.
     pub handle: Option<u32>,
     #[serde(rename = "type")]
+    #[new(into)]
     /// The ct helper type name, e.g. "ftp" or "tftp".
     pub _type: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// The ct helper’s layer 4 protocol.
     pub protocol: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// The ct helper’s layer 3 protocol, e.g. "ip" or "ip6".
     pub l3proto: Option<Cow<'a, str>>,
 }
@@ -709,7 +755,8 @@ impl Default for CTHelper<'_> {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// This object represents a named [limit](Limit).
 ///
 /// A limit uses a [token bucket](Token bucket) filter to match packets:
@@ -721,8 +768,10 @@ impl Default for CTHelper<'_> {
 pub struct Limit<'a> {
     /// The [table](Table)’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The [table](Table)’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The limit’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -763,7 +812,7 @@ impl Default for Limit<'_> {
     }
 }
 
-#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Hash, Serialize, Deserialize, JsonSchema, new)]
 #[serde(rename_all = "lowercase")]
 /// A unit used in [limits](Limit).
 pub enum LimitUnit {
@@ -773,14 +822,17 @@ pub enum LimitUnit {
     Bytes,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 pub struct Meter<'a> {
     pub name: Cow<'a, str>,
     pub key: Expression<'a>,
+    #[new(into)]
     pub stmt: Box<Statement<'a>>,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// Represents the live ruleset (to be [flushed](NfCmd::Flush)).
 pub struct Ruleset {}
 
@@ -791,16 +843,19 @@ impl Default for Ruleset {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// Library information in output.
 ///
 /// In output, the first object in an nftables array is a special one containing library information.
 pub struct MetainfoObject<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// The value of version property is equal to the package version as printed by `nft -v`.
     pub version: Option<Cow<'a, str>>,
-    /// The value of release_name property is equal to the release name as printed by `nft -v`.
+    #[new(into)]
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// The value of release_name property is equal to the release name as printed by `nft -v`.
     pub release_name: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The JSON Schema version.
@@ -824,7 +879,8 @@ impl Default for MetainfoObject<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// This object represents a named [conntrack timeout][Ct timeout] policy.
 ///
 /// You can use a ct timeout object to specify a connection tracking timeout policy for a particular flow.
@@ -833,8 +889,10 @@ impl Default for MetainfoObject<'_> {
 pub struct CTTimeout<'a> {
     /// The table’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The table’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The ct timeout object’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -844,12 +902,14 @@ pub struct CTTimeout<'a> {
     /// The ct timeout object’s [layer 4 protocol](CTHProto).
     pub protocol: Option<CTHProto>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// The connection state name, e.g. "established", "syn_sent", "close" or "close_wait", for which the timeout value has to be updated.
     pub state: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The updated timeout value for the specified connection state.
     pub value: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// The ct timeout object’s layer 3 protocol, e.g. "ip" or "ip6".
     pub l3proto: Option<Cow<'a, str>>,
 }
@@ -870,21 +930,25 @@ impl Default for CTTimeout<'_> {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 /// This object represents a named [conntrack expectation][Ct expectation].
 ///
 /// [Ct expectation]: <https://wiki.nftables.org/wiki-nftables/index.php/Ct_expectation>
 pub struct CTExpectation<'a> {
     /// The table’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The table’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The ct expectation object’s name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     /// The ct expectation object’s handle. In input, it is used by delete command only.
     pub handle: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[new(into)]
     /// The ct expectation object’s layer 3 protocol, e.g. "ip" or "ip6".
     pub l3proto: Option<Cow<'a, str>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -907,12 +971,15 @@ pub struct CTExpectation<'a> {
 /// Named SynProxy requires **nftables 0.9.3 or newer**.
 ///
 /// [SynProxy]: https://wiki.nftables.org/wiki-nftables/index.php/Synproxy
-#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Builder, new)]
+#[builder(build_fn(error = "NftablesError"), setter(into, strip_option))]
 pub struct SynProxy<'a> {
     /// The table’s family.
     pub family: NfFamily,
+    #[new(into)]
     /// The table’s name.
     pub table: Cow<'a, str>,
+    #[new(into)]
     /// The synproxy's name.
     pub name: Cow<'a, str>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This PR utilises the [`derive_builder`](https://crates.io/derive_builder) and [`derive_new`](https://crates.io/derive_new) crates to allow for better library usability and decreased code verbosity.

Changes:
- `#[derive(Builder)]` on relevant structs.
- `#[derive(new)]` on relevant structs and enums.
- `#[new(into)]` on types: `Cow<'a, T>`, `Option<Cow<'a, T>>` or `Box<T>`.
- Renamed `NftablesError` to `NftExecutableError`.
- Created an error type `NftablesError` in `src/error.rs` to handle auto-generated builder errors. This allow for better error handling because library users can do `impl From<NftablesError> for OwnError {}`.

Notes:
- This PR probably needs some more documentation as there are some breaking changes.
- There are some inconsistencies in the formatting of procedural macros and comments. For example: 
```
    #[new(into)]
    /// The table’s name.
    pub table: Cow<'a, str>,
    
    /// The table’s name.
    #[new(into)]
    pub table: Cow<'a, str>,
```