### PR TITLE
Support for set auto-merge and counter

### DIFF
--- a/src/expr.rs
+++ b/src/expr.rs
@@ -89,6 +89,8 @@ pub enum NamedExpression<'a> {
     /// This expression is typically used in the [LHS](crate::stmt::Match::left)
     /// of a [match](crate::stmt::Match) statement.
     Osf(Osf<'a>),
+    /// Enable a counter per element. Available since nftables 0.9.5.
+    Counter(Option<bool>),
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize, JsonSchema)]

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -332,6 +332,12 @@ pub struct Set<'a> {
     /// Garbage collector interval in seconds.
     pub gc_interval: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    /// Optional set statements.
+    pub stmt: Option<Cow<'a, [Expression<'a>]>>,
+    #[serde(rename = "auto-merge", skip_serializing_if = "Option::is_none")]
+    /// Whether adjacent set elements get automatically merged. This is only valid for interval sets.
+    pub auto_merge: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     /// Maximum number of elements supported.
     pub size: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -355,6 +361,8 @@ impl Default for Set<'_> {
             elem: None,
             timeout: None,
             gc_interval: None,
+            stmt: None,
+            auto_merge: None,
             size: None,
             comment: None,
         }


### PR DESCRIPTION
Fixes #116.

I have not figured out how the test suite for this crate works, so I just tested on my machine for now.

Test snippet:
```rust
    batch.add(schema::NfListObject::Table(schema::Table {
        family: types::NfFamily::INet,
        name: "test_table".into(),
        ..Default::default()
    }));
    batch.add(schema::NfListObject::Set(Box::new(schema::Set {
        family: types::NfFamily::INet,
        table: "test_table".into(),
        name: "ipset6".into(),
        set_type: schema::SetTypeValue::Single(schema::SetType::Ipv6Addr),
        flags: Some(HashSet::from([schema::SetFlag::Interval])),
        stmt: Some(
            vec![expr::Expression::Named(expr::NamedExpression::Counter(
                None,
            ))]
            .into(),
        ),
        auto_merge: Some(true),
        ..Default::default()
    })));
```
Expected ruleset:
```
table inet test_table {
	set ipset6 {
		type ipv6_addr
		flags interval
		counter
		auto-merge
	}
}
```
Actual JSON from `nft -j list ruleset`
```
[
    {
      "table": {
        "family": "inet",
        "name": "test_table",
        "handle": 21
      }
    },
    {
      "set": {
        "family": "inet",
        "name": "ipset6",
        "table": "test_table",
        "type": "ipv6_addr",
        "handle": 2,
        "flags": [
          "interval"
        ],
        "auto-merge": true,
        "stmt": [
          {
            "counter": null
          }
        ]
      }
    }
]
```

Working full example: https://github.com/myzhang1029/logblock/blob/main/src/nft.rs